### PR TITLE
Fix connection not becoming active

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,17 +21,29 @@ func main() {
 		fmt.Println(message.Text)
 	})
 	go client.Connect()
-ConnectionLoop:
-	for {
-		select {
-		case error := <-client.ErrChan:
-			fmt.Println(error.Error())
-			break ConnectionLoop
-		default:
-			break
-		}
-		client.Join("gempir")
-	}
+	client.Join("gempir")
+	client.Say("gempir", "Hello!")
+
+	// If you wish to read an input message from the command line and then send it to the chat, you could do the following:
+	//
+	// 	scanner := bufio.NewScanner(os.Stdin)
+	// ConnectionLoop:
+	// 	for {
+	// 		select {
+	// 		case error := <-client.ErrChan:
+	// 			fmt.Println(error.Error())
+	// 			break ConnectionLoop
+	// 		default:
+	// 			break
+	// 		}
+	// 		for scanner.Scan() {
+	// 			s := scanner.Text()
+	// 			client.Say("gempir", s)
+	// 		}
+	// 		if err := scanner.Err(); err != nil {
+	// 			os.Exit(1)
+	// 		}
+	//	}
 }
 ```
 ### Available Data

--- a/README.MD
+++ b/README.MD
@@ -15,14 +15,23 @@ import (
 
 func main() {
 	client := twitch.NewClient("justinfan123123", "oauth:123123123")
+	client.ErrChan = make(chan error)
 
 	client.OnNewMessage(func(channel string, user twitch.User, message twitch.Message) {
 		fmt.Println(message.Text)
 	})
-
-	client.Join("gempir")
-
-	client.Connect()
+	go client.Connect()
+ConnectionLoop:
+	for {
+		select {
+		case error := <-client.ErrChan:
+			fmt.Println(error.Error())
+			break ConnectionLoop
+		default:
+			break
+		}
+		client.Join("gempir")
+	}
 }
 ```
 ### Available Data

--- a/client.go
+++ b/client.go
@@ -80,7 +80,7 @@ func (c *Client) Join(channel string) {
 	c.send(fmt.Sprintf("JOIN #%s", channel))
 }
 
-// Connect connect the client to the irc server
+// Connect connect the client to the irc server - NOTE: must be used as a go routine!
 func (c *Client) Connect() {
 	var conf *tls.Config
 	// This means we are connecting to "localhost". Disable certificate chain check
@@ -98,7 +98,6 @@ func (c *Client) Connect() {
 			c.ErrChan <- err
 			return
 		}
-		c.ErrChan <- nil
 
 		c.setupConnection()
 


### PR DESCRIPTION
Fix #10 

- Client is now able to join a channel and send/receive messages.
- Changed `Connect()` so it is now used as a go routine and reports errors through a channel.
- Update the example in README.md

NOTE: This PR breaks all the tests, but this will be fixed in a future PR related to #8 