### PR TITLE
WIP: add onNewReconnectMessage and improve test coverage

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -54,10 +54,11 @@ Channel is just a string like "lirik", note the absent #.
 ### Message Types
 
 If you ever need more than basic PRIVMSG this might be for you.
-These are the 5 major message types currently supported
+These are the 6 major message types currently supported
 
 	PRIVMSG
 	WHISPER
 	ROOMSTATE
 	CLEARCHAT
 	USERNOTICE
+	RECONNECT

--- a/client.go
+++ b/client.go
@@ -50,6 +50,8 @@ type Client struct {
 	onNewRoomstateMessage  func(channel string, user User, message Message)
 	onNewClearchatMessage  func(channel string, user User, message Message)
 	onNewUsernoticeMessage func(channel string, user User, message Message)
+	onNewReconnectMessage  func()
+	quitKeepAlive          chan struct{}
 }
 
 // NewClient to create a new client
@@ -86,6 +88,12 @@ func (c *Client) OnNewUsernoticeMessage(callback func(channel string, user User,
 	c.onNewUsernoticeMessage = callback
 }
 
+// OnNewReconnectMessage attach callback to new reconnect message
+// or when a PING timeout causes keepConnectionAlive() to reconnect
+func (c *Client) OnNewReconnectMessage(callback func()) {
+	c.onNewReconnectMessage = callback
+}
+
 // Say write something in a chat
 func (c *Client) Say(channel, text string) {
 	c.send(fmt.Sprintf("PRIVMSG #%s :%s", channel, text))
@@ -107,6 +115,9 @@ func (c *Client) Join(channel string) {
 // Disconnect close current connection
 func (c *Client) Disconnect() error {
 	c.connActive.set(false)
+	if c.quitKeepAlive != nil {
+		close(c.quitKeepAlive)
+	}
 	if c.connection != nil {
 		return c.connection.Close()
 	}
@@ -172,9 +183,12 @@ func (c *Client) setupConnection() {
 	go c.keepConnectionAlive()
 }
 
+// keepAliveInterval is for decreasing the duration tests
+var keepAliveInterval = 500 * time.Second
+
 func (c *Client) keepConnectionAlive() {
-	ticker := time.NewTicker(500 * time.Second)
-	quit := make(chan struct{})
+	ticker := time.NewTicker(keepAliveInterval)
+	c.quitKeepAlive = make(chan struct{})
 	go func() {
 		for {
 			select {
@@ -184,7 +198,7 @@ func (c *Client) keepConnectionAlive() {
 					c.Connect()
 				}
 				c.wasPinged.set(false)
-			case <-quit:
+			case <-c.quitKeepAlive:
 				ticker.Stop()
 				return
 			}
@@ -251,6 +265,10 @@ func (c *Client) handleLine(line string) {
 		case USERNOTICE:
 			if c.onNewUsernoticeMessage != nil {
 				c.onNewUsernoticeMessage(Channel, *User, *clientMessage)
+			}
+		case RECONNECT:
+			if c.onNewReconnectMessage != nil {
+				c.onNewReconnectMessage()
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -218,6 +218,14 @@ func (c *Client) send(line string) {
 }
 
 func (c *Client) handleLine(line string) {
+	if line == ":tmi.twitch.tv RECONNECT" {
+		if c.onNewReconnectMessage != nil {
+			c.onNewReconnectMessage()
+		}
+		c.Disconnect()
+		c.Connect()
+		return
+	}
 	if strings.HasPrefix(line, "PING") {
 		c.send(strings.Replace(line, "PING", "PONG", 1))
 		c.wasPinged.set(true)
@@ -265,10 +273,6 @@ func (c *Client) handleLine(line string) {
 		case USERNOTICE:
 			if c.onNewUsernoticeMessage != nil {
 				c.onNewUsernoticeMessage(Channel, *User, *clientMessage)
-			}
-		case RECONNECT:
-			if c.onNewReconnectMessage != nil {
-				c.onNewReconnectMessage()
 			}
 		}
 	}

--- a/message.go
+++ b/message.go
@@ -88,14 +88,15 @@ func parseMessage(line string) *message {
 func parseOtherMessage(line string) *message {
 	msg := &message{}
 	split := strings.Split(line, " ")
-
+	if split[1] == "RECONNECT" {
+		msg.Type = RECONNECT
+		return msg
+	}
 	switch split[2] {
 	case "ROOMSTATE":
 		msg.Type = ROOMSTATE
 	case "USERNOTICE":
 		msg.Type = USERNOTICE
-	case "RECONNECT":
-		msg.Type = RECONNECT
 	}
 	msg.Tags = make(map[string]string)
 

--- a/message.go
+++ b/message.go
@@ -20,6 +20,8 @@ const (
 	ROOMSTATE = 3
 	// USERNOTICE messages like subs, resubs, raids, etc
 	USERNOTICE = 4
+	// RECONNECT message
+	RECONNECT = 5
 )
 
 type message struct {
@@ -92,6 +94,8 @@ func parseOtherMessage(line string) *message {
 		msg.Type = ROOMSTATE
 	case "USERNOTICE":
 		msg.Type = USERNOTICE
+	case "RECONNECT":
+		msg.Type = RECONNECT
 	}
 	msg.Tags = make(map[string]string)
 

--- a/message_test.go
+++ b/message_test.go
@@ -113,3 +113,13 @@ func TestCanParseRoomstateMessage(t *testing.T) {
 		t.Error("parsing ROOMSTATE message failed")
 	}
 }
+func TestCanParseReconnectMessage(t *testing.T) {
+	testMessage := `:tmi.twitch.tv RECONNECT`
+
+	message := parseOtherMessage(testMessage)
+
+	if message.Type != RECONNECT {
+		t.Error("parsing RECONNECT message failed")
+	}
+	assertIntsEqual(t, 5, int(message.Type))
+}


### PR DESCRIPTION
This improves upon #25 by adding an interval that can be shortened for tests.  Feel free to reject and/or improve upon this if this approach is too messy.