### PR TITLE
Fix ACTION (/me) parsing

### DIFF
--- a/message.go
+++ b/message.go
@@ -54,9 +54,9 @@ func parseMessage(line string) *message {
 	}
 	action := false
 	tags, middle, text := spl[0], spl[1], spl[2]
-	if strings.HasPrefix(text, "\u0001ACTION ") {
+	if strings.HasPrefix(text, "\u0001ACTION ") && strings.HasSuffix(text, "\u0001"){
 		action = true
-		text = text[8:]
+		text = text[8:len(text)-1]
 	}
 	msg := &message{
 		Time:   time.Now(),

--- a/message_test.go
+++ b/message_test.go
@@ -24,7 +24,7 @@ func TestCanParseMessage(t *testing.T) {
 }
 
 func TestCanParseActionMessage(t *testing.T) {
-	testMessage := "@badges=subscriber/6,premium/1;color=#FF0000;display-name=Redflamingo13;emotes=;id=2a31a9df-d6ff-4840-b211-a2547c7e656e;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1490382457309;turbo=0;user-id=78424343;user-type= :redflamingo13!redflamingo13@redflamingo13.tmi.twitch.tv PRIVMSG #pajlada :\u0001ACTION Thrashh5, FeelsWayTooAmazingMan kinda"
+	testMessage := "@badges=subscriber/6,premium/1;color=#FF0000;display-name=Redflamingo13;emotes=;id=2a31a9df-d6ff-4840-b211-a2547c7e656e;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1490382457309;turbo=0;user-id=78424343;user-type= :redflamingo13!redflamingo13@redflamingo13.tmi.twitch.tv PRIVMSG #pajlada :\u0001ACTION Thrashh5, FeelsWayTooAmazingMan kinda\u0001"
 	message := parseMessage(testMessage)
 
 	assertStringsEqual(t, "pajlada", message.Channel)


### PR DESCRIPTION
Twitch /me messages also append a \u0001 character at the end of the message. This was not parsed properly.

The changes fix the issue, and the test case for action messages has been updated.

Minimal test to show the bug in the last version
Join the chat at https://twitch.tv/pajlada/chat and type an Action message (i.e. `/me test`) and you will see the issue
```go
package main

import (
	"fmt"

	"github.com/gempir/go-twitch-irc"
)

func main() {
	client := twitch.NewClient("justinfan695", "oauth:kjhdfgj")

	client.OnNewMessage(func(channel string, user twitch.User, message twitch.Message) {
		if message.Action {
			fmt.Printf("'%s' will incorrectly end with a \u0001\n", message.Text)
		}
	})

	client.Join("pajlada")

	err := client.Connect()
	if err != nil {
		panic(err)
	}
}
```
