### PR TITLE
Fix clearchat parsing

### DIFF
--- a/message.go
+++ b/message.go
@@ -92,6 +92,8 @@ func parseOtherMessage(line string) *message {
 		msg.Type = ROOMSTATE
 	case "USERNOTICE":
 		msg.Type = USERNOTICE
+	case "CLEARCHAT":
+		msg.Type = CLEARCHAT
 	}
 	msg.Tags = make(map[string]string)
 
@@ -106,6 +108,10 @@ func parseOtherMessage(line string) *message {
 		}
 
 		msg.Tags[tagSplit[0]] = value
+	}
+
+	if msg.Type == CLEARCHAT {
+		msg.Text = "Chat has been cleared by a moderator"
 	}
 	return msg
 }

--- a/message_test.go
+++ b/message_test.go
@@ -84,6 +84,20 @@ func TestCanParseClearChatMessage(t *testing.T) {
 	if message.Type != CLEARCHAT {
 		t.Error("parsing CLEARCHAT message failed")
 	}
+
+	assertStringsEqual(t, message.Channel, "pajlada")
+}
+
+func TestCanParseClearChatMessage2(t *testing.T) {
+	testMessage := `@room-id=11148817;tmi-sent-ts=1527342985836 :tmi.twitch.tv CLEARCHAT #pajlada`
+
+	message := parseMessage(testMessage)
+
+	if message.Type != CLEARCHAT {
+		t.Error("parsing CLEARCHAT message failed")
+	}
+
+	assertStringsEqual(t, message.Channel, "pajlada")
 }
 
 func TestCanParseEmoteMessage(t *testing.T) {


### PR DESCRIPTION
This fixes normal `/clear` commands, since previously `OnNewClearchatMessage` only triggered when someone was timed out