### PR TITLE
Join/Rejoin channels on successful connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	ircToken               string
 	connection             *tls.Conn
 	connActive             tAtomBool
+	channels               map[string]bool
 	onNewWhisper           func(user User, message Message)
 	onNewMessage           func(channel string, user User, message Message)
 	onNewRoomstateMessage  func(channel string, user User, message Message)
@@ -57,6 +58,7 @@ func NewClient(username, oauth string) *Client {
 		ircUser:    username,
 		ircToken:   oauth,
 		IrcAddress: ircTwitch,
+		channels:   map[string]bool{},
 	}
 }
 
@@ -100,7 +102,13 @@ func (c *Client) Whisper(username, text string) {
 
 // Join enter a twitch channel to read more messages
 func (c *Client) Join(channel string) {
-	go c.send(fmt.Sprintf("JOIN #%s", channel))
+	// If we don't have the channel in our map AND we have an
+	// active connection, explicitly join before we add it to our map
+	if !c.channels[channel] && c.connActive.get() {
+		go c.send(fmt.Sprintf("JOIN #%s", channel))
+	}
+
+	c.channels[channel] = true
 }
 
 // Depart leave a twitch channel
@@ -173,6 +181,11 @@ func (c *Client) setupConnection() {
 	c.connection.Write([]byte("NICK " + c.ircUser + "\r\n"))
 	c.connection.Write([]byte("CAP REQ :twitch.tv/tags\r\n"))
 	c.connection.Write([]byte("CAP REQ :twitch.tv/commands\r\n"))
+
+	// join or rejoin channels on connection
+	for channel := range c.channels {
+		c.send(fmt.Sprintf("JOIN #%s", channel))
+	}
 }
 
 func (c *Client) send(line string) {

--- a/client_test.go
+++ b/client_test.go
@@ -643,6 +643,79 @@ func TestCanJoinChannel(t *testing.T) {
 	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
 }
 
+func TestCanJoinChannelAfterConnection(t *testing.T) {
+	wait := make(chan struct{})
+
+	waitEnd := make(chan struct{})
+	var receivedMsg string
+
+	go func() {
+		cer, err := tls.LoadX509KeyPair("test_resources/server.crt", "test_resources/server.key")
+		if err != nil {
+			log.Println(err)
+			return
+		}
+		config := &tls.Config{
+			Certificates: []tls.Certificate{cer},
+		}
+		ln, err := tls.Listen("tcp", ":4350", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(wait)
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		tp := textproto.NewReader(reader)
+
+		for {
+			message, err := tp.ReadLine()
+			if err != nil && err != io.EOF {
+				t.Fatal(err)
+			}
+			message = strings.Replace(message, "\r\n", "", 1)
+			if strings.HasPrefix(message, "NICK") {
+				fmt.Fprintf(conn, ":tmi.twitch.tv 001 justinfan123123 :Welcome, GLHF!\r\n")
+			}
+			if strings.HasPrefix(message, "JOIN") {
+				receivedMsg = message
+				close(waitEnd)
+			}
+		}
+	}()
+
+	// wait for server to start
+	select {
+	case <-wait:
+	case <-time.After(time.Second * 3):
+		t.Fatal("testserver didn't start")
+	}
+
+	client := NewClient("justinfan123123", "oauth:123123132")
+	client.IrcAddress = ":4350"
+	go client.Connect()
+
+	// wait for the connection to go active
+	for !client.connActive.get() {
+		time.Sleep(time.Millisecond * 2)
+	}
+	client.Join("gempir")
+
+	// wait for server to receive message
+	select {
+	case <-waitEnd:
+	case <-time.After(time.Second * 3):
+		t.Fatal("no join message received")
+	}
+
+	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
+}
+
 func TestCanDepartChannel(t *testing.T) {
 	wait := make(chan struct{})
 


### PR DESCRIPTION
Previously `client.Join` was an explicit send of the join command to the
server. This meant that if your connection was dropped and you
reconnected you would not join any channels on successful reconnection.

This change updates that so a map of channels is maintained so that if
the connection is lost, upon successful reconnection all of the channels
are rejoined.

Due to the way join worked previously, it could be called before or
after `client.Connect`, so careful consideration was taken to ensure
that the same behavior is retained with this change.

Addresses issue #34