### PR TITLE
Client.Join is not case sensitive.

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,6 +111,8 @@ func (c *Client) Whisper(username, text string) {
 
 // Join enter a twitch channel to read more messages
 func (c *Client) Join(channel string) {
+	channel = strings.ToLower(channel)
+
 	// If we don't have the channel in our map AND we have an
 	// active connection, explicitly join before we add it to our map
 	c.channelsMtx.Lock()

--- a/client_test.go
+++ b/client_test.go
@@ -347,7 +347,7 @@ func TestCanJoinChannel(t *testing.T) {
 	client := newTestClient(host)
 	go client.Connect()
 
-	client.Join("gempir")
+	client.Join("gempiR")
 
 	// wait for server to receive message
 	select {


### PR DESCRIPTION
Had the problem that if I copy-pasted channel names from Twitch that contained uppercase characters ( DisguisedToastHS ), it didn't error out or gave me any warning, it just didn't give me any messages.

One approach is to just make the argument in Client.Join lowercase in the beginning.
What do you think?

``` go
func main() {
	c := twitch.NewClient("tinee", "oauth:abcdefg")

	c.OnNewMessage(func(channel string, user twitch.User, message twitch.Message) {
		fmt.Println(message.Text)
	})

        // This will not work because all channels is lowercase.
	c.Join("DisguisedToastHS")
        c.Connect()
}
```
