### PR TITLE
Add support for membership, exposing a userlist and joins/parts callbacks

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -60,7 +60,7 @@ These are the available methods of the client so you can get your bot going:
 	func (c *Client) Whisper(username, text string)
 	func (c *Client) Join(channel string)
 	func (c *Client) Depart(channel string)
-	func (c *Client) Userlist(channel string) (map[string]bool, err)
+	func (c *Client) Userlist(channel string) ([]string, err)
 	func (c *Client) Connect() error
 	func (c *Client) Disconnect() error
 

--- a/README.MD
+++ b/README.MD
@@ -60,6 +60,7 @@ These are the available methods of the client so you can get your bot going:
 	func (c *Client) Whisper(username, text string)
 	func (c *Client) Join(channel string)
 	func (c *Client) Depart(channel string)
+	func (c *Client) Userlist(channel string) (map[string]bool, err)
 	func (c *Client) Connect() error
 	func (c *Client) Disconnect() error
 
@@ -81,6 +82,8 @@ client.OnNewRoomstateMessage(func(channel string, user twitch.User, message twit
 client.OnNewClearchatMessage(func(channel string, user twitch.User, message twitch.Message) {})
 client.OnNewUsernoticeMessage(func(channel string, user twitch.User, message twitch.Message) {})
 client.OnNewUserstateMessage(func(channel string, user twitch.User, message twitch.Message) {})
+client.OnUserJoin(func(channel, user string) {})
+client.OnUserPart(func(channel, user string) {})
 ```
 ### Message Types
 

--- a/README.MD
+++ b/README.MD
@@ -60,7 +60,7 @@ These are the available methods of the client so you can get your bot going:
 	func (c *Client) Whisper(username, text string)
 	func (c *Client) Join(channel string)
 	func (c *Client) Depart(channel string)
-	func (c *Client) Userlist(channel string) ([]string, err)
+	func (c *Client) Userlist(channel string) ([]string, error)
 	func (c *Client) Connect() error
 	func (c *Client) Disconnect() error
 

--- a/client.go
+++ b/client.go
@@ -115,12 +115,12 @@ func (c *Client) OnNewUserstateMessage(callback func(channel string, user User, 
 	c.onNewUserstateMessage = callback
 }
 
-// OnUserJoin attack callback to user join
+// OnUserJoin attaches callback to user joins
 func (c *Client) OnUserJoin(callback func(channel, user string)) {
 	c.onUserJoin = callback
 }
 
-// OnUserPart attack callback to user part
+// OnUserPart attaches callback to user parts
 func (c *Client) OnUserPart(callback func(channel, user string)) {
 	c.onUserPart = callback
 }
@@ -315,7 +315,7 @@ func (c *Client) handleLine(line string) {
 		}
 	}
 	if strings.HasPrefix(line, ":") {
-		if strings.Contains(line, "JOIN") {
+		if strings.Contains(line, "tmi.twitch.tv JOIN") {
 			channel, username := parseJoinPart(line)
 
 			if username != c.ircUser && !isInSlice(username, c.channelUserlist[channel]) {
@@ -326,7 +326,7 @@ func (c *Client) handleLine(line string) {
 				c.onUserJoin(channel, username)
 			}
 		}
-		if strings.Contains(line, "PART") {
+		if strings.Contains(line, "tmi.twitch.tv PART") {
 			channel, username := parseJoinPart(line)
 
 			c.channelUserlist[channel] = removeElement(username, c.channelUserlist[channel])

--- a/client.go
+++ b/client.go
@@ -345,10 +345,6 @@ func (c *Client) handleLine(line string) {
 		if strings.Contains(line, "353 "+c.ircUser) {
 			channel, users := parseNames(line)
 
-			if c.channelUserlist[channel] == nil {
-				c.channelUserlist[channel] = map[string]bool{}
-			}
-
 			for _, user := range users {
 				c.channelUserlist[channel][user] = true
 			}

--- a/client.go
+++ b/client.go
@@ -225,11 +225,20 @@ func (c *Client) Connect() error {
 }
 
 // Userlist returns the userlist for a given channel
-func (c *Client) Userlist(channel string) (map[string]bool, error) {
-	if value, ok := c.channelUserlist[channel]; ok {
-		return value, nil
+func (c *Client) Userlist(channel string) ([]string, error) {
+	usermap, ok := c.channelUserlist[channel]
+	if !ok || usermap == nil {
+		return nil, fmt.Errorf("Could not find userlist for channel '%s' in client", channel)
 	}
-	return nil, fmt.Errorf("Could not find userlist for channel '%s' in client", channel)
+	userlist := make([]string, len(usermap))
+
+	i := 0
+	for key := range usermap {
+		userlist[i] = key
+		i++
+	}
+
+	return userlist, nil
 }
 
 func (c *Client) readConnection(conn net.Conn) error {

--- a/client_test.go
+++ b/client_test.go
@@ -580,23 +580,18 @@ func TestCanGetUserlist(t *testing.T) {
 	}
 
 	// test a valid channel
-	userlist, err := client.Userlist("channel123")
+	got, err := client.Userlist("channel123")
 	if err != nil {
 		t.Fatal("error not nil for client.Userlist")
 	}
 	expected := []string{"username1", "username2"}
-	got := make([]string, 0, 2)
-
-	for key := range userlist {
-		got = append(got, key)
-	}
 
 	sort.Strings(got)
 	assertStringSlicesEqual(t, expected, got)
 
 	// test an unknown channel
-	userlist, err = client.Userlist("random_channel123")
-	if err == nil || userlist != nil {
+	got, err = client.Userlist("random_channel123")
+	if err == nil || got != nil {
 		t.Fatal("error expected on unknown channel for client.Userlist")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/textproto"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -578,10 +579,26 @@ func TestCanGetUserlist(t *testing.T) {
 		time.Sleep(time.Millisecond * 5)
 	}
 
-	got := client.Userlist("channel123")
+	// test a valid channel
+	userlist, err := client.Userlist("channel123")
+	if err != nil {
+		t.Fatal("error not nil for client.Userlist")
+	}
 	expected := []string{"username1", "username2"}
+	got := make([]string, 0, 2)
 
+	for key := range userlist {
+		got = append(got, key)
+	}
+
+	sort.Strings(got)
 	assertStringSlicesEqual(t, expected, got)
+
+	// test an unknown channel
+	userlist, err = client.Userlist("random_channel123")
+	if err == nil || userlist != nil {
+		t.Fatal("error expected on unknown channel for client.Userlist")
+	}
 
 	close(waitEnd)
 
@@ -687,22 +704,4 @@ func TestCanConnectToTwitchWithoutTLS(t *testing.T) {
 	})
 
 	client.Connect()
-}
-
-func TestRemoveElement(t *testing.T) {
-	input := []string{"1", "2", "3", "4"}
-	expected := []string{"1", "2", "3"}
-
-	output := removeElement("4", input)
-
-	assertStringSlicesEqual(t, expected, output)
-}
-
-func TestIsInSlice(t *testing.T) {
-	input := []string{"1", "2", "3"}
-	yes := isInSlice("2", input)
-	no := isInSlice("100", input)
-
-	assertTrue(t, yes, "expected true for \"2\" is in slice")
-	assertTrue(t, no == false, "expected false for \"100\" is not slice")
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -31,3 +31,19 @@ func assertFalse(t *testing.T, actual bool, errorMessage string) {
 		t.Error(errorMessage)
 	}
 }
+
+func assertStringSlicesEqual(t *testing.T, expected, actual []string) {
+	if actual == nil {
+		t.Errorf("actual slice was nil")
+	}
+
+	if len(actual) != len(expected) {
+		t.Errorf("actual slice was not the same length as expected slice")
+	}
+
+	for i, v := range actual {
+		if v != expected[i] {
+			t.Errorf("actual slice value \"%s\" was not equal to expected value \"%s\" at index \"%d\"", v, expected[i], i)
+		}
+	}
+}

--- a/message.go
+++ b/message.go
@@ -231,3 +231,18 @@ func parseTwitchEmotes(emoteTag, text string) []*Emote {
 	}
 	return emotes
 }
+
+func parseJoinPart(text string) (string, string) {
+	username := strings.Split(text, "!")
+	channel := strings.Split(username[1], "#")
+	return strings.Trim(channel[1], " "), strings.Trim(username[0], " :")
+}
+
+func parseNames(text string) (string, []string) {
+	lines := strings.Split(text, ":")
+	channelDirty := strings.Split(lines[1], "#")
+	channel := strings.Trim(channelDirty[1], " ")
+	users := strings.Split(lines[2], " ")
+
+	return channel, users
+}

--- a/message_test.go
+++ b/message_test.go
@@ -143,3 +143,23 @@ func TestCanParseRoomstateMessage(t *testing.T) {
 
 	assertStringsEqual(t, message.Channel, "nothing")
 }
+
+func TestCanParseJoinPart(t *testing.T) {
+	testMessage := `:username123!username123@username123.tmi.twitch.tv JOIN #mychannel`
+
+	channel, username := parseJoinPart(testMessage)
+
+	assertStringsEqual(t, channel, "mychannel")
+	assertStringsEqual(t, username, "username123")
+}
+
+func TestCanParseNames(t *testing.T) {
+	testMessage := `:myusername123.tmi.twitch.tv 353 myusername123 = #mychannel :username1 username2 username3 username4`
+	expectedUsers := []string{"username1", "username2", "username3", "username4"}
+
+	channel, users := parseNames(testMessage)
+
+	assertStringsEqual(t, channel, "mychannel")
+
+	assertStringSlicesEqual(t, expectedUsers, users)
+}

--- a/message_test.go
+++ b/message_test.go
@@ -160,6 +160,5 @@ func TestCanParseNames(t *testing.T) {
 	channel, users := parseNames(testMessage)
 
 	assertStringsEqual(t, channel, "mychannel")
-
 	assertStringSlicesEqual(t, expectedUsers, users)
 }


### PR DESCRIPTION
- added support for twitch irc [membership](https://dev.twitch.tv/docs/irc/membership/), keeping a userlist that's updated on every `NAMES`, `JOIN` and `PART`
- exposed a new `Client` method which returns the current userlist for a given channel:
```go
client.Userlist(channel string) []string
```
- added `OnUserJoin` and `OnUserPart` callbacks, giving the channel and user to the caller, allowing for things like join/part messages or other custom handling _(the user param here has to be a string here as the join/part messages contain next to no info, so I couldn't use the `User` struct unless we want to fill it with mostly dummy/assumed info)_

also added tests for everything and a new test helper for string slices, all tests pass for me and everything in some trivial tests, should close #20 

