### PR TITLE
Add new MessageType UNSET, which is now the default MessageType

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,6 +68,7 @@ type Client struct {
 	onNewUserstateMessage  func(channel string, user User, message Message)
 	onUserJoin             func(channel, user string)
 	onUserPart             func(channel, user string)
+	onNewUnsetMessage      func(rawMessage string)
 }
 
 // NewClient to create a new client
@@ -130,6 +131,11 @@ func (c *Client) OnUserJoin(callback func(channel, user string)) {
 // OnUserPart attaches callback to user parts
 func (c *Client) OnUserPart(callback func(channel, user string)) {
 	c.onUserPart = callback
+}
+
+// OnNewUnsetMessage attaches callback to messages that didn't parse properly. Should only be used if you're debugging the message parsing
+func (c *Client) OnNewUnsetMessage(callback func(rawMessage string)) {
+	c.onNewUnsetMessage = callback
 }
 
 // Say write something in a chat
@@ -333,6 +339,10 @@ func (c *Client) handleLine(line string) {
 		case USERSTATE:
 			if c.onNewUserstateMessage != nil {
 				c.onNewUserstateMessage(channel, *user, *clientMessage)
+			}
+		case UNSET:
+			if c.onNewUnsetMessage != nil {
+				c.onNewUnsetMessage(clientMessage.Raw)
 			}
 		}
 	}

--- a/message.go
+++ b/message.go
@@ -11,6 +11,8 @@ import (
 type MessageType int
 
 const (
+	// UNSET
+	UNSET MessageType = -1
 	// WHISPER private messages
 	WHISPER MessageType = 0
 	// PRIVMSG standard chat message
@@ -57,6 +59,7 @@ func parseMessage(line string) *message {
 		return &message{
 			Text: line,
 			Raw:  line,
+			Type: UNSET,
 		}
 	}
 	spl := strings.SplitN(line, " :", 3)
@@ -73,6 +76,7 @@ func parseMessage(line string) *message {
 		Text:   text,
 		Tags:   map[string]string{},
 		Action: action,
+		Type:   UNSET,
 	}
 	msg.Username, msg.Type, msg.Channel = parseMiddle(middle)
 	parseTags(msg, tags[1:])
@@ -87,7 +91,9 @@ func parseMessage(line string) *message {
 }
 
 func parseOtherMessage(line string) *message {
-	msg := &message{}
+	msg := &message{
+		Type: UNSET,
+	}
 	split := strings.Split(line, " ")
 	msg.Raw = line
 
@@ -120,25 +126,24 @@ func parseOtherMessage(line string) *message {
 }
 
 func parseMessageType(messageType string) MessageType {
-	var msgType MessageType
 	switch messageType {
 	case "PRIVMSG":
-		msgType = PRIVMSG
+		return PRIVMSG
 	case "WHISPER":
-		msgType = WHISPER
+		return WHISPER
 	case "CLEARCHAT":
-		msgType = CLEARCHAT
+		return CLEARCHAT
 	case "NOTICE":
-		msgType = NOTICE
+		return NOTICE
 	case "ROOMSTATE":
-		msgType = ROOMSTATE
+		return ROOMSTATE
 	case "USERSTATE":
-		msgType = USERSTATE
+		return USERSTATE
 	case "USERNOTICE":
-		msgType = USERNOTICE
+		return USERNOTICE
+	default:
+		return UNSET
 	}
-
-	return msgType
 }
 
 func parseMiddle(middle string) (string, MessageType, string) {


### PR DESCRIPTION
Previously, any messages that didn't parse their messageType properly
would just leave the MessageType as the default (which was WHISPER)

 - Add a "developer" `OnNewUnsetMessage` function.
this is useful for finding messages that don't parse properly in go-twitch-irc.