### PR TITLE
Error out from Connect on bad/malformed oauth

### DIFF
--- a/client.go
+++ b/client.go
@@ -398,8 +398,6 @@ func (c *Client) handleLine(line string) error {
 		if strings.Contains(line, "tmi.twitch.tv NOTICE * :Login authentication failed") || strings.Contains(line, "tmi.twitch.tv NOTICE * :Improperly formatted auth") {
 			return ErrLoginAuthenticationFailed
 		}
-
-		return nil
 	}
 
 	return nil


### PR DESCRIPTION
Parsing should be fine, only thing I could imagine being contested is whether the error should be split up into two: Login authentication failed and Improperly formatted auth

Fixes #55 