### PR TITLE
Fix Client.Say is case sensitive

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,6 +174,8 @@ func (c *Client) OnNewUnsetMessage(callback func(rawMessage string)) {
 
 // Say write something in a chat
 func (c *Client) Say(channel, text string) {
+	channel = strings.ToLower(channel)
+
 	c.send(fmt.Sprintf("PRIVMSG #%s :%s", channel, text))
 }
 


### PR DESCRIPTION
If I used the channel Display Name as the first argument in Client.Say(), it wouldn't throw an error or send the message to chat. I also checked Client.Whisper() but it seems that is already case insensitive.

I fixed Client.Say by adding using a ToLower on the channel.

```go
package main

import (
	twitch "github.com/gempir/go-twitch-irc"
)

func main() {
	c := twitch.NewClient("ClippyAssistant", "oauth:abcdef")

	c.OnNewMessage(func(channel string, user twitch.User, message twitch.Message) {
		// This will silently fail to send
		c.Say("ClippyAssistant", "Hello there!")
	})

	c.Join("ClippyAssistant")
	c.Connect()
}
```