### PR TITLE
Implement Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/gempir/go-twitch-irc


### PR DESCRIPTION
Resolves #80 

This will allows users with Go 1.11.0+ to control when they upgrade their libraries/binaries to the next major version, even after we've merged it into master.

When we are ready to release v2.0.0, we just need to update the first line to include `/v2` at the end, and then increment it for future MAJOR releases.

In Go 1.12, the go.mod file indicates the version of the language used by the files within that module. However, this makes it [not compatible with 1.11.3](https://github.com/golang/go/issues/30446#issuecomment-468044008) or earlier. As we don't use any 1.12 features, I've removed the line.

For more information about how to work with Go Modules, read [this](https://roberto.selbach.ca/intro-to-go-modules/).