### PR TITLE
Fixes #67 and adds recoverMessage function

### DIFF
--- a/message.go
+++ b/message.go
@@ -456,6 +456,10 @@ func parseEmotes(rawEmotes, message string) []*Emote {
 		firstIndex, _ := strconv.Atoi(pair[0])
 		lastIndex, _ := strconv.Atoi(pair[1])
 
+		if lastIndex+1 > len(runes) {
+			lastIndex--
+		}
+
 		emote := &Emote{
 			Name:  string(runes[firstIndex : lastIndex+1]),
 			ID:    split[0],

--- a/message.go
+++ b/message.go
@@ -1,8 +1,6 @@
 package twitch
 
 import (
-	"log"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -81,7 +79,8 @@ type Emote struct {
 
 // ParseMessage parse a raw Twitch IRC message
 func ParseMessage(line string) Message {
-	defer recoverMessage(line)
+	// Uncomment this and recoverMessage if debugging a message that crashes the parser
+	//defer recoverMessage(line)
 
 	ircMessage, err := parseIRCMessage(line)
 	if err != nil {
@@ -95,13 +94,13 @@ func ParseMessage(line string) Message {
 	return parseRawMessage(ircMessage)
 }
 
-func recoverMessage(line string) {
-	if err := recover(); err != nil {
-		log.Println(line)
-		log.Println(err)
-		log.Println(string(debug.Stack()))
-	}
-}
+// func recoverMessage(line string) {
+// 	if err := recover(); err != nil {
+// 		log.Println(line)
+// 		log.Println(err)
+// 		log.Println(string(debug.Stack()))
+// 	}
+// }
 
 // parseMessageType parses a message type from an irc COMMAND string
 func parseMessageType(messageType string) MessageType {

--- a/message.go
+++ b/message.go
@@ -1,6 +1,8 @@
 package twitch
 
 import (
+	"log"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -79,6 +81,8 @@ type Emote struct {
 
 // ParseMessage parse a raw Twitch IRC message
 func ParseMessage(line string) Message {
+	defer recoverMessage(line)
+
 	ircMessage, err := parseIRCMessage(line)
 	if err != nil {
 		return parseRawMessage(ircMessage)
@@ -89,6 +93,14 @@ func ParseMessage(line string) Message {
 	}
 
 	return parseRawMessage(ircMessage)
+}
+
+func recoverMessage(line string) {
+	if err := recover(); err != nil {
+		log.Println(line)
+		log.Println(err)
+		log.Println(string(debug.Stack()))
+	}
 }
 
 // parseMessageType parses a message type from an irc COMMAND string

--- a/message_test.go
+++ b/message_test.go
@@ -67,6 +67,20 @@ func TestCantParsePartialMessage(t *testing.T) {
 	assertStringsEqual(t, "", rawMessage.Message)
 }
 
+func TestCanParseSliceOutOfBoundsMessage(t *testing.T) {
+	testMessage := "@badge-info=;badges=;color=#D2691E;display-name=xSpeedHack;emotes=245:38-52;flags=28-35:A.6/I.6;id=ebf30552-c327-4602-a346-582ecc880ab5;mod=0;room-id=23304775;subscriber=0;tmi-sent-ts=1556302007395;turbo=0;user-id=189609555;user-type= :xspeedhack!xspeedhack@xspeedhack.tmi.twitch.tv PRIVMSG #turntheslayer :Чет скушные катки Жек когда Хачаги?! ResidentSleeper"
+
+	message := ParseMessage(testMessage)
+	privateMessage := message.(*PrivateMessage)
+
+	if privateMessage.Type != PRIVMSG {
+		t.Error("parsing MessageType failed")
+	}
+	assertStringsEqual(t, "PRIVMSG", privateMessage.RawType)
+	assertStringsEqual(t, "Чет скушные катки Жек когда Хачаги?! ResidentSleeper", privateMessage.Message)
+	assertIntsEqual(t, 1, len(privateMessage.Emotes))
+}
+
 func TestCanParseWHISPERMessage(t *testing.T) {
 	testMessage := "@badges=;color=#00FF7F;display-name=Danielps1;emotes=;message-id=20;thread-id=32591953_77829817;turbo=0;user-id=32591953;user-type= :danielps1!danielps1@danielps1.tmi.twitch.tv WHISPER gempir :i like memes"
 


### PR DESCRIPTION
Fixes #67 

The recoverMessage function helped identify offending messages, and should prevent similar issues in the future killing clients.

At the moment, it logs the raw message, error, and stack trace to console. If wanted, we could write it to an error.logs file. That way we can simply review it at the end of the session, instead of keeping an eye on the console.