### PR TITLE
Update go.mod to reflect v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/gempir/go-twitch-irc
+module github.com/gempir/go-twitch-irc/v2


### PR DESCRIPTION
If the module is version v2 or higher, the major version of the module must be included as a /vN at the end of the module paths used in go.mod files (e.g., module github.com/my/mod/v2, require github.com/my/mod/v2 v2.0.0) and in the package import path (e.g., import "github.com/my/mod/v2/mypkg").

Source: https://github.com/golang/go/wiki/Modules#semantic-import-versioning