### PR TITLE
Rejoin properly

### DIFF
--- a/client.go
+++ b/client.go
@@ -841,6 +841,7 @@ func (c *Client) initialJoins() {
 	channels := []string{}
 	for channel := range c.channels {
 		channels = append(channels, channel)
+		c.channels[channel] = false
 	}
 	c.Join(channels...)
 }


### PR DESCRIPTION
The rejoin functionality of go-twitch-irc was broken in a #105 or #106 
this should fix it