### PR TITLE
Set minimum go version to 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/gempir/go-twitch-irc/v2
+
+go 1.12


### PR DESCRIPTION
After trying to build the repo with various go versions (in the github ci test branch) I've come to the conclusion that the library does not build with Go below version 1.12.
This should be reflected in the `go.mod` file as done in this PR.
