### PR TITLE
Make caps modifiable

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -237,3 +237,31 @@ These are the 7 major message types currently supported:
     NOTICE
     JOIN
     PART
+
+### Capabilities
+
+By default, the Client sends along all 3 Twitch capabilities (Tags, Commands, Membership).  
+Information about each capability can be found here:
+ * Tags: https://dev.twitch.tv/docs/irc/tags
+ * Commands https://dev.twitch.tv/docs/irc/commands
+ * Membership https://dev.twitch.tv/docs/irc/membership
+
+If you want to modify which capabilities that are sent, you can modify the `Capabilities` variable in the client before calling Connect
+
+Example:
+```go
+client := twitch.NewClient("yourtwitchusername", "oauth:123123123")
+
+client.Capabilities = nil
+
+// or
+
+client.Capabilities = []string{twitch.TagsCapability, twitch.CommandsCapability}
+
+client.Join("gempir")
+
+err := client.Connect()
+if err != nil {
+    panic(err)
+}
+```

--- a/README.MD
+++ b/README.MD
@@ -211,11 +211,7 @@ Option modifications must be done before calling Connect on the client.
 
 #### Capabilities
 
-By default, the Client sends along all 3 Twitch capabilities (Tags, Commands, Membership).  
-Information about each capability can be found here:
- * Tags: https://dev.twitch.tv/docs/irc/tags
- * Commands https://dev.twitch.tv/docs/irc/commands
- * Membership https://dev.twitch.tv/docs/irc/membership
+By default, the Client sends along all 3 Twitch capabilities ([Tags](https://dev.twitch.tv/docs/irc/tags), [Commands](https://dev.twitch.tv/docs/irc/commands), [Membership](https://dev.twitch.tv/docs/irc/membership)).  
 
 ### Callbacks
 

--- a/README.MD
+++ b/README.MD
@@ -204,7 +204,19 @@ On your client you can configure multiple options:
 client.IrcAddress = "127.0.0.1:3030" // for custom irc server
 client.TLS = false // enabled by default, will connect to non TLS server of twitch when off or the given client.IrcAddress
 client.SetupCmd = "LOGIN custom_command_here" // Send a custom command on successful IRC connection, before authentication.
+client.Capabilities = []string{twitch.TagsCapability, twitch.CommandsCapability} // Customize which capabilities are sent
 ```
+
+Option modifications must be done before calling Connect on the client.
+
+#### Capabilities
+
+By default, the Client sends along all 3 Twitch capabilities (Tags, Commands, Membership).  
+Information about each capability can be found here:
+ * Tags: https://dev.twitch.tv/docs/irc/tags
+ * Commands https://dev.twitch.tv/docs/irc/commands
+ * Membership https://dev.twitch.tv/docs/irc/membership
+
 ### Callbacks
 
 These callbacks are available to pass to the client:
@@ -237,31 +249,3 @@ These are the 7 major message types currently supported:
     NOTICE
     JOIN
     PART
-
-### Capabilities
-
-By default, the Client sends along all 3 Twitch capabilities (Tags, Commands, Membership).  
-Information about each capability can be found here:
- * Tags: https://dev.twitch.tv/docs/irc/tags
- * Commands https://dev.twitch.tv/docs/irc/commands
- * Membership https://dev.twitch.tv/docs/irc/membership
-
-If you want to modify which capabilities that are sent, you can modify the `Capabilities` variable in the client before calling Connect
-
-Example:
-```go
-client := twitch.NewClient("yourtwitchusername", "oauth:123123123")
-
-client.Capabilities = nil
-
-// or
-
-client.Capabilities = []string{twitch.TagsCapability, twitch.CommandsCapability}
-
-client.Join("gempir")
-
-err := client.Connect()
-if err != nil {
-    panic(err)
-}
-```

--- a/README.MD
+++ b/README.MD
@@ -211,7 +211,7 @@ Option modifications must be done before calling Connect on the client.
 
 #### Capabilities
 
-By default, the Client sends along all 3 Twitch capabilities ([Tags](https://dev.twitch.tv/docs/irc/tags), [Commands](https://dev.twitch.tv/docs/irc/commands), [Membership](https://dev.twitch.tv/docs/irc/membership)).  
+By default, the client sends along all 3 Twitch capabilities ([Tags](https://dev.twitch.tv/docs/irc/tags), [Commands](https://dev.twitch.tv/docs/irc/commands), [Membership](https://dev.twitch.tv/docs/irc/membership)).  
 
 ### Callbacks
 

--- a/client.go
+++ b/client.go
@@ -21,14 +21,14 @@ const (
 	pingSignature = "go-twitch-irc"
 	pingMessage   = "PING :" + pingSignature
 
-	// TagsCap for Twitch's Tags capabilities, see https://dev.twitch.tv/docs/irc/tags
-	TagsCap = "twitch.tv/tags"
+	// TagsCapability for Twitch's Tags capabilities, see https://dev.twitch.tv/docs/irc/tags
+	TagsCapability = "twitch.tv/tags"
 
-	// CommandsCap for Twitch's Commands capabilities, see https://dev.twitch.tv/docs/irc/commands
-	CommandsCap = "twitch.tv/commands"
+	// CommandsCapability for Twitch's Commands capabilities, see https://dev.twitch.tv/docs/irc/commands
+	CommandsCapability = "twitch.tv/commands"
 
-	// MembershipCap for Twitch's Membership capabilities, see https://dev.twitch.tv/docs/irc/membership
-	MembershipCap = "twitch.tv/membership"
+	// MembershipCapability for Twitch's Membership capabilities, see https://dev.twitch.tv/docs/irc/membership
+	MembershipCapability = "twitch.tv/membership"
 )
 
 var (
@@ -49,8 +49,8 @@ var (
 	// Must be configured before NewClient is called to take effect
 	ReadBufferSize = 64
 
-	// DefaultCaps is the default caps when creating a new Client
-	DefaultCaps = []string{TagsCap, CommandsCap, MembershipCap}
+	// DefaultCapabilities is the default caps when creating a new Client
+	DefaultCapabilities = []string{TagsCapability, CommandsCapability, MembershipCapability}
 )
 
 // Internal errors
@@ -403,9 +403,10 @@ type Client struct {
 	// The variable must be modified before calling Connect or the command will not run.
 	SetupCmd string
 
-	// Caps is the list of CAPs that should be sent as part of the connection setup
+	// Capabilities is the list of capabilities that should be sent as part of the connection setup
 	// By default, this is all caps (Tags, Commands, Membership)
-	Caps []string
+	// If this is an empty list or nil, no CAP REQ message is sent at all
+	Capabilities []string
 }
 
 // NewClient to create a new client
@@ -429,7 +430,7 @@ func NewClient(username, oauth string) *Client {
 
 		channelUserlistMutex: &sync.RWMutex{},
 
-		Caps: DefaultCaps,
+		Capabilities: DefaultCapabilities,
 	}
 }
 
@@ -809,8 +810,8 @@ func (c *Client) setupConnection(conn net.Conn) {
 	if c.SetupCmd != "" {
 		conn.Write([]byte(c.SetupCmd + "\r\n"))
 	}
-	if len(c.Caps) > 0 {
-		_, _ = conn.Write([]byte("CAP REQ :" + strings.Join(c.Caps, " ") + "\r\n"))
+	if len(c.Capabilities) > 0 {
+		_, _ = conn.Write([]byte("CAP REQ :" + strings.Join(c.Capabilities, " ") + "\r\n"))
 	}
 	conn.Write([]byte("PASS " + c.ircToken + "\r\n"))
 	conn.Write([]byte("NICK " + c.ircUser + "\r\n"))

--- a/client.go
+++ b/client.go
@@ -810,7 +810,7 @@ func (c *Client) setupConnection(conn net.Conn) {
 		conn.Write([]byte(c.SetupCmd + "\r\n"))
 	}
 	if len(c.Caps) > 0 {
-		conn.Write([]byte("CAP REQ :" + strings.Join(c.Caps, " ") + "\r\n"))
+		_, _ = conn.Write([]byte("CAP REQ :" + strings.Join(c.Caps, " ") + "\r\n"))
 	}
 	conn.Write([]byte("PASS " + c.ircToken + "\r\n"))
 	conn.Write([]byte("NICK " + c.ircUser + "\r\n"))

--- a/client_test.go
+++ b/client_test.go
@@ -1930,15 +1930,23 @@ func TestRejoinOnReconnect(t *testing.T) {
 	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
 }
 
-func TestCaps(t *testing.T) {
+func TestCapabilities(t *testing.T) {
 	type testTable struct {
 		name     string
 		in       []string
 		expected string
 	}
 	var tests = []testTable{
-		{"Default Caps (not modifying)", nil, "CAP REQ :" + strings.Join([]string{TagsCap, CommandsCap, MembershipCap}, " ")},
-		{"Modified Caps", []string{CommandsCap, MembershipCap}, "CAP REQ :" + strings.Join([]string{CommandsCap, MembershipCap}, " ")},
+		{
+			"Default Capabilities (not modifying)",
+			nil,
+			"CAP REQ :" + strings.Join([]string{TagsCapability, CommandsCapability, MembershipCapability}, " "),
+		},
+		{
+			"Modified Capabilities",
+			[]string{CommandsCapability, MembershipCapability},
+			"CAP REQ :" + strings.Join([]string{CommandsCapability, MembershipCapability}, " "),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1960,7 +1968,7 @@ func TestCaps(t *testing.T) {
 
 				client := newTestClient(server.host)
 				if tt.in != nil {
-					client.Caps = tt.in
+					client.Capabilities = tt.in
 				}
 				client.OnConnect(clientCloseOnConnect(waitClientConnect))
 				clientDisconnected := connectAndEnsureGoodDisconnect(t, client)
@@ -1998,7 +2006,7 @@ func TestCaps(t *testing.T) {
 	}
 }
 
-func TestEmptyCaps(t *testing.T) {
+func TestEmptyCapabilities(t *testing.T) {
 	type testTable struct {
 		name string
 		in   []string
@@ -2013,21 +2021,21 @@ func TestEmptyCaps(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 				// we will modify the clients caps to only send commands and membership
-				receivedCaps := false
+				receivedCapabilities := false
 				waitRecv := make(chan struct{})
 				waitServerConnect := make(chan struct{})
 				waitClientConnect := make(chan struct{})
 
 				server := startServer2(t, closeOnConnect(waitServerConnect), func(message string) {
 					if strings.HasPrefix(message, "CAP REQ") {
-						receivedCaps = true
+						receivedCapabilities = true
 					} else if strings.HasPrefix(message, "PASS") {
 						close(waitRecv)
 					}
 				})
 
 				client := newTestClient(server.host)
-				client.Caps = tt.in
+				client.Capabilities = tt.in
 				client.OnConnect(clientCloseOnConnect(waitClientConnect))
 				clientDisconnected := connectAndEnsureGoodDisconnect(t, client)
 
@@ -2036,7 +2044,7 @@ func TestEmptyCaps(t *testing.T) {
 					t.Fatal("no oauth read")
 				}
 
-				assertFalse(t, receivedCaps, "We should NOT have received caps since we sent an empty list of caps")
+				assertFalse(t, receivedCapabilities, "We should NOT have received caps since we sent an empty list of caps")
 
 				// Wait for server to acknowledge connection
 				if !waitWithTimeout(waitServerConnect) {

--- a/client_test.go
+++ b/client_test.go
@@ -1929,3 +1929,132 @@ func TestRejoinOnReconnect(t *testing.T) {
 	// Server received second JOIN message
 	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
 }
+
+func TestCaps(t *testing.T) {
+	var tests = []struct {
+		name     string
+		in       []string
+		expected string
+	}{
+		{"Default Caps (not modifying)", nil, "CAP REQ :" + strings.Join([]string{TagsCap, CommandsCap, MembershipCap}, " ")},
+		{"Modified Caps", []string{CommandsCap, MembershipCap}, "CAP REQ :" + strings.Join([]string{CommandsCap, MembershipCap}, " ")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			waitRecv := make(chan struct{})
+			waitServerConnect := make(chan struct{})
+			waitClientConnect := make(chan struct{})
+
+			var received string
+
+			server := startServer2(t, closeOnConnect(waitServerConnect), func(message string) {
+				if strings.HasPrefix(message, "CAP REQ") {
+					received = message
+					close(waitRecv)
+				}
+			})
+
+			client := newTestClient(server.host)
+			if tt.in != nil {
+				client.Caps = tt.in
+			}
+			client.OnConnect(clientCloseOnConnect(waitClientConnect))
+			clientDisconnected := connectAndEnsureGoodDisconnect(t, client)
+
+			// Wait for correct password to be read in server
+			if !waitWithTimeout(waitRecv) {
+				t.Fatal("no oauth read")
+			}
+
+			assertStringsEqual(t, tt.expected, received)
+
+			// Wait for server to acknowledge connection
+			if !waitWithTimeout(waitServerConnect) {
+				t.Fatal("no successful connection")
+			}
+
+			// Wait for client to acknowledge connection
+			if !waitWithTimeout(waitClientConnect) {
+				t.Fatal("no successful connection")
+			}
+
+			// Disconnect client from server
+			err := client.Disconnect()
+			if err != nil {
+				t.Error("Error during disconnect:" + err.Error())
+			}
+
+			// Wait for client to be fully disconnected
+			<-clientDisconnected
+
+			// Wait for server to be fully disconnected
+			<-server.stopped
+		})
+	}
+}
+
+func TestEmptyCaps(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   []string
+	}{
+		{"nil", nil},
+		{"Empty list", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// we will modify the clients caps to only send commands and membership
+			receivedCaps := false
+			waitRecv := make(chan struct{})
+			waitServerConnect := make(chan struct{})
+			waitClientConnect := make(chan struct{})
+
+			server := startServer2(t, closeOnConnect(waitServerConnect), func(message string) {
+				if strings.HasPrefix(message, "CAP REQ") {
+					receivedCaps = true
+				} else if strings.HasPrefix(message, "PASS") {
+					close(waitRecv)
+				}
+			})
+
+			client := newTestClient(server.host)
+			client.Caps = tt.in
+			client.OnConnect(clientCloseOnConnect(waitClientConnect))
+			clientDisconnected := connectAndEnsureGoodDisconnect(t, client)
+
+			// Wait for correct password to be read in server
+			if !waitWithTimeout(waitRecv) {
+				t.Fatal("no oauth read")
+			}
+
+			assertFalse(t, receivedCaps, "We should NOT have received caps since we sent an empty list of caps")
+
+			// Wait for server to acknowledge connection
+			if !waitWithTimeout(waitServerConnect) {
+				t.Fatal("no successful connection")
+			}
+
+			// Wait for client to acknowledge connection
+			if !waitWithTimeout(waitClientConnect) {
+				t.Fatal("no successful connection")
+			}
+
+			// Disconnect client from server
+			err := client.Disconnect()
+			if err != nil {
+				t.Error("Error during disconnect:" + err.Error())
+			}
+
+			// Wait for client to be fully disconnected
+			<-clientDisconnected
+
+			// Wait for server to be fully disconnected
+			<-server.stopped
+
+		})
+	}
+}


### PR DESCRIPTION
caps can be modified by changing the clients .Caps member before
connecting.
See tests for example

Use the const values when making your own list of caps to send along

Note that the default caps we send might change in the future

Works on #126 

I don't think this PR is the right time to change the default Caps, but with this in place I think we're better prepared to change them.