### PR TITLE
Add commands RestrictChatForFollowers and AllowChatForEverybody

### DIFF
--- a/client.go
+++ b/client.go
@@ -585,6 +585,16 @@ func (c *Client) Join(channels ...string) {
 	c.channelsMtx.Unlock()
 }
 
+// FollowersOn run twitch command `/followers` with the given channel and duration in argument
+func (c *Client) FollowersOn(channel, duration string) {
+	c.Say(channel, "/followers "+duration)
+}
+
+// FollowersOn run twitch command `/followersoff` with the given channel in argument
+func (c *Client) FollowersOff(channel string) {
+	c.Say(channel, "/followersoff")
+}
+
 // Creates an irc join message to join the given channels.
 //
 // Returns the join message, any channels included in the join message,
@@ -1102,14 +1112,6 @@ func (c *Client) handlePongMessage(msg PongMessage) {
 		default:
 		}
 	}
-}
-
-func (c *Client) RestrictChatForFollowers(channel string, duration string) {
-	c.Say(channel, "/followers "+duration)
-}
-
-func (c *Client) AllowChatForEverybody(channel string) {
-	c.Say(channel, "/followersoff")
 }
 
 // chanCloser is a helper function for abusing channels for notifications

--- a/client.go
+++ b/client.go
@@ -1104,6 +1104,14 @@ func (c *Client) handlePongMessage(msg PongMessage) {
 	}
 }
 
+func (c *Client) RestrictChatForFollowers(channel string, duration string) {
+	c.Say(channel, "/followers "+duration)
+}
+
+func (c *Client) AllowChatForEverybody(channel string) {
+	c.Say(channel, "/followersoff")
+}
+
 // chanCloser is a helper function for abusing channels for notifications
 // this is an easy "notify many" channel
 type chanCloser struct {

--- a/client_test.go
+++ b/client_test.go
@@ -1113,7 +1113,7 @@ func TestCanRunFollowersOn(t *testing.T) {
 		client.FollowersOn("gempiR", "30m")
 	})
 
-	go client.Connect()
+	go client.Connect() //nolint
 
 	// wait for server to receive message
 	select {
@@ -1144,7 +1144,7 @@ func TestCanRunFollowersOff(t *testing.T) {
 		client.FollowersOff("gempiR")
 	})
 
-	go client.Connect()
+	go client.Connect() //nolint
 
 	// wait for server to receive message
 	select {

--- a/client_test.go
+++ b/client_test.go
@@ -1094,7 +1094,7 @@ func TestCanJoinChannel(t *testing.T) {
 	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
 }
 
-func TestCanRestrictChatForFollowers(t *testing.T) {
+func TestCanRunFollowersOn(t *testing.T) {
 	t.Parallel()
 
 	waitEnd := make(chan struct{})
@@ -1110,7 +1110,7 @@ func TestCanRestrictChatForFollowers(t *testing.T) {
 	client := newTestClient(host)
 
 	client.OnConnect(func() {
-		client.RestrictChatForFollowers("gempiR", "30m")
+		client.FollowersOn("gempiR", "30m")
 	})
 
 	go client.Connect()
@@ -1125,7 +1125,7 @@ func TestCanRestrictChatForFollowers(t *testing.T) {
 	assertStringsEqual(t, "PRIVMSG #gempir :/followers 30m", received)
 }
 
-func TestCanAllowChatForEverybody(t *testing.T) {
+func TestCanRunFollowersOff(t *testing.T) {
 	t.Parallel()
 
 	waitEnd := make(chan struct{})
@@ -1141,7 +1141,7 @@ func TestCanAllowChatForEverybody(t *testing.T) {
 	client := newTestClient(host)
 
 	client.OnConnect(func() {
-		client.AllowChatForEverybody("gempiR")
+		client.FollowersOff("gempiR")
 	})
 
 	go client.Connect()

--- a/client_test.go
+++ b/client_test.go
@@ -1094,6 +1094,68 @@ func TestCanJoinChannel(t *testing.T) {
 	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
 }
 
+func TestCanRestrictChatForFollowers(t *testing.T) {
+	t.Parallel()
+
+	waitEnd := make(chan struct{})
+	var received string
+
+	host := startServer(t, nothingOnConnect, func(message string) {
+		if strings.HasPrefix(message, "PRIVMSG") {
+			received = message
+			close(waitEnd)
+		}
+	})
+
+	client := newTestClient(host)
+
+	client.OnConnect(func() {
+		client.RestrictChatForFollowers("gempiR", "30m")
+	})
+
+	go client.Connect()
+
+	// wait for server to receive message
+	select {
+	case <-waitEnd:
+	case <-time.After(time.Second * 3):
+		t.Fatal("no privmsg received")
+	}
+
+	assertStringsEqual(t, "PRIVMSG #gempir :/followers 30m", received)
+}
+
+func TestCanAllowChatForEverybody(t *testing.T) {
+	t.Parallel()
+
+	waitEnd := make(chan struct{})
+	var received string
+
+	host := startServer(t, nothingOnConnect, func(message string) {
+		if strings.HasPrefix(message, "PRIVMSG") {
+			received = message
+			close(waitEnd)
+		}
+	})
+
+	client := newTestClient(host)
+
+	client.OnConnect(func() {
+		client.AllowChatForEverybody("gempiR")
+	})
+
+	go client.Connect()
+
+	// wait for server to receive message
+	select {
+	case <-waitEnd:
+	case <-time.After(time.Second * 3):
+		t.Fatal("no privmsg received")
+	}
+
+	assertStringsEqual(t, "PRIVMSG #gempir :/followersoff", received)
+}
+
 func TestCanJoinChannelAfterConnection(t *testing.T) {
 	t.Parallel()
 	waitEnd := make(chan struct{})


### PR DESCRIPTION
Resolves issue #137:
- `RestrictChatForFollowers`: Runs twitch `/followers` command with channel and duration arguments
- `AllowChatForEverybody`: Runs twitch `/followersoff` command with channel argument