### PR TITLE
Implement twitch ratelimits

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1022,7 +1022,8 @@ func TestCanSayMessage(t *testing.T) {
 	client := newTestClient(host)
 
 	client.OnConnect(func() {
-		client.Say("gempir", testMessage)
+		client.Join("gempirTestCanSayMessage")
+		client.Say("gempirTestCanSayMessage", testMessage)
 	})
 
 	go client.Connect()
@@ -1034,7 +1035,7 @@ func TestCanSayMessage(t *testing.T) {
 		t.Fatal("no privmsg received")
 	}
 
-	assertStringsEqual(t, "PRIVMSG #gempir :"+testMessage, received)
+	assertStringsEqual(t, "PRIVMSG #gempirtestcansaymessage :"+testMessage, received)
 }
 
 func TestCanWhisperMessage(t *testing.T) {
@@ -1080,7 +1081,7 @@ func TestCanJoinChannel(t *testing.T) {
 
 	client := newTestClient(host)
 
-	client.Join("gempiR")
+	client.Join("gempiRTestCanJoinChannel")
 
 	go client.Connect()
 
@@ -1091,7 +1092,7 @@ func TestCanJoinChannel(t *testing.T) {
 		t.Fatal("no join message received")
 	}
 
-	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
+	assertStringsEqual(t, "JOIN #gempirtestcanjoinchannel", receivedMsg)
 }
 
 func TestCanRunFollowersOn(t *testing.T) {
@@ -1109,8 +1110,9 @@ func TestCanRunFollowersOn(t *testing.T) {
 
 	client := newTestClient(host)
 
+	client.Join("gempirtestcanrunfollowerson")
 	client.OnConnect(func() {
-		client.FollowersOn("gempiR", "30m")
+		client.FollowersOn("gempirtestcanrunfollowerson", "30m")
 	})
 
 	go client.Connect() //nolint
@@ -1122,7 +1124,7 @@ func TestCanRunFollowersOn(t *testing.T) {
 		t.Fatal("no privmsg received")
 	}
 
-	assertStringsEqual(t, "PRIVMSG #gempir :/followers 30m", received)
+	assertStringsEqual(t, "PRIVMSG #gempirtestcanrunfollowerson :/followers 30m", received)
 }
 
 func TestCanRunFollowersOff(t *testing.T) {
@@ -1140,8 +1142,9 @@ func TestCanRunFollowersOff(t *testing.T) {
 
 	client := newTestClient(host)
 
+	client.Join("gempirtestcanrunfollowersoff")
 	client.OnConnect(func() {
-		client.FollowersOff("gempiR")
+		client.FollowersOff("gempirtestcanrunfollowersoff")
 	})
 
 	go client.Connect() //nolint
@@ -1153,7 +1156,7 @@ func TestCanRunFollowersOff(t *testing.T) {
 		t.Fatal("no privmsg received")
 	}
 
-	assertStringsEqual(t, "PRIVMSG #gempir :/followersoff", received)
+	assertStringsEqual(t, "PRIVMSG #gempirtestcanrunfollowersoff :/followersoff", received)
 }
 
 func TestCanJoinChannelAfterConnection(t *testing.T) {
@@ -1175,7 +1178,7 @@ func TestCanJoinChannelAfterConnection(t *testing.T) {
 	for !client.connActive.get() {
 		time.Sleep(time.Millisecond * 2)
 	}
-	client.Join("gempir")
+	client.Join("gempirTestCanJoinChannelAfterConnection")
 
 	// wait for server to receive message
 	select {
@@ -1184,7 +1187,7 @@ func TestCanJoinChannelAfterConnection(t *testing.T) {
 		t.Fatal("no join message received")
 	}
 
-	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
+	assertStringsEqual(t, "JOIN #gempirtestcanjoinchannelafterconnection", receivedMsg)
 }
 
 func TestCanDepartChannel(t *testing.T) {
@@ -1296,8 +1299,8 @@ func TestDepartNegatesJoinIfNotConnected(t *testing.T) {
 
 	client := newTestClient(host)
 
-	client.Join("gempir")
-	client.Depart("gempir")
+	client.Join("gempirtestdepartnegatesjoinifnotconnected")
+	client.Depart("gempirtestdepartnegatesjoinifnotconnected")
 
 	go client.Connect()
 
@@ -1987,7 +1990,7 @@ func TestRejoinOnReconnect(t *testing.T) {
 
 	client := newTestClient(host)
 
-	client.Join("gempiR")
+	client.Join("gempiRTestRejoinOnReconnect")
 
 	go client.Connect()
 
@@ -1999,7 +2002,7 @@ func TestRejoinOnReconnect(t *testing.T) {
 	}
 
 	// Server received first JOIN message
-	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
+	assertStringsEqual(t, "JOIN #gempirtestrejoinonreconnect", receivedMsg)
 
 	receivedMsg = ""
 
@@ -2013,11 +2016,12 @@ func TestRejoinOnReconnect(t *testing.T) {
 	select {
 	case <-waitEnd:
 	case <-time.After(time.Second * 3):
+		//TODO determine why this is nondeterministic and sometimes errors
 		t.Fatal("no join message received 2")
 	}
 
 	// Server received second JOIN message
-	assertStringsEqual(t, "JOIN #gempir", receivedMsg)
+	assertStringsEqual(t, "JOIN #gempirtestrejoinonreconnect", receivedMsg)
 }
 
 func TestCapabilities(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gempir/go-twitch-irc/v2
 
-go 1.12
+go 1.15

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,330 @@
+package twitch
+
+import (
+	"container/list"
+	"context"
+	"time"
+)
+
+//startMiddlewares initializes the tracker tickers/contexts and middlewares.
+func (c *Client) startMiddlewares() {
+
+	//guard agains multiple middlewares.
+	c.stopMiddlewares()
+
+	c.whisperLimiter.startTracker(c.whisperRatelimit)
+	go c.whisperMiddleware()
+	c.authLimiter.startTracker(c.authRateLimit)
+	go c.authMiddleware()
+	c.joinLimiter.startTracker(c.joinRateLimit)
+	go c.joinMiddleware()
+
+	for channel, tracker := range c.sayLimiters {
+		if tracker.isMod {
+			tracker.startTracker(c.sayModRateLimit)
+		} else {
+			tracker.startTracker(c.sayRateLimit)
+		}
+		go c.sayMiddleware(channel)
+	}
+}
+
+//SetWhisperRateLimit sets the ratelimit of whispers.
+func (c *Client) SetWhisperRateLimit(rateTime time.Duration) {
+	c.whisperRatelimit = rateTime
+	c.whisperLimiter.ticker.Reset(rateTime)
+}
+
+//SetJoinRateLimit updates the ratelimit of joins.
+func (c *Client) SetJoinRateLimit(rateTime time.Duration) {
+	c.joinRateLimit = rateTime
+	c.joinLimiter.ticker.Reset(rateTime)
+}
+
+//SetAuthRateLimit updates the rate limit of Authentication Requests.
+func (c *Client) SetAuthRateLimit(rateTime time.Duration) {
+	c.authRateLimit = rateTime
+	c.authLimiter.ticker.Reset(rateTime)
+}
+
+//SetSayRateLimit updates the moderator/operator and unknown rate limits for Say requests.
+func (c *Client) SetSayRateLimit(modRateTime, unknownRateTime time.Duration) {
+	c.sayModRateLimit = modRateTime
+	c.sayRateLimit = unknownRateTime
+	for _, tracker := range c.sayLimiters {
+		if tracker.isMod {
+			tracker.ticker.Reset(modRateTime)
+		} else {
+			tracker.ticker.Reset(unknownRateTime)
+		}
+	}
+}
+
+//SetIgnoreRateLimitsBot sets the bot to ignore all ratelimits. This includes SAY rate limits.
+func (c *Client) SetIgnoreRateLimitsBot() {
+	c.SetWhisperRateLimit(IgnoreRatelimit)
+	c.SetAuthRateLimit(IgnoreRatelimit)
+	c.SetJoinRateLimit(IgnoreRatelimit)
+	c.SetSayRateLimit(IgnoreRatelimit, IgnoreRatelimit)
+}
+
+//SetVerifiedBot updates all ratelimits to use those of a verified bot. This includes SAY rate limits.
+func (c *Client) SetVerifiedBot() {
+	c.SetWhisperRateLimit(VerifiedBotWhisper)
+	c.SetAuthRateLimit(VerifiedBotAuth)
+	c.SetJoinRateLimit(VerifiedBotJoin)
+	c.SetSayRateLimit(ModeratorBotSay, UnknownBotSay)
+}
+
+//SetKnownBot updates all rate limits to use those of a known bot. This includes SAY rate limits.
+func (c *Client) SetKnownBot() {
+	c.SetWhisperRateLimit(KnownBotWhisper)
+	c.SetAuthRateLimit(KnownBotAuth)
+	c.SetJoinRateLimit(KnownBotJoin)
+	c.SetSayRateLimit(ModeratorBotSay, UnknownBotSay)
+}
+
+//SetUnknownBot updates all rate limits to use those of an unknown bot. This includes SAY rate limits.
+func (c *Client) SetUnknownBot() {
+	c.SetWhisperRateLimit(UnknownBotWhisper)
+	c.SetAuthRateLimit(UnknownBotAuth)
+	c.SetJoinRateLimit(UnknownBotJoin)
+	c.SetSayRateLimit(ModeratorBotSay, UnknownBotSay)
+}
+
+//BecomeModded Updates the input channel to have the correct mod status and updates the ticker respectively.
+func (c *Client) BecomeModded(channel string) { //TODO use somewhere.
+	c.sayLimiters[channel].isMod = true
+	c.sayLimiters[channel].ticker.Reset(c.sayModRateLimit)
+}
+
+//BecomeUnModded Updates the input channel to have the correct mod status and updates the ticker respectively.
+func (c *Client) BecomeUnModded(channel string) { //TODO use somewhere.
+	c.sayLimiters[channel].isMod = false
+	c.sayLimiters[channel].ticker.Reset(c.sayRateLimit)
+}
+
+//stopMiddlewares stops the middlewares for all of the middlewares. Use when disconnected to stop tickers.
+func (c *Client) stopMiddlewares() {
+
+	c.whisperLimiter.stopTracker()
+	c.authLimiter.stopTracker()
+	c.joinLimiter.stopTracker()
+
+	for _, tracker := range c.sayLimiters {
+
+		tracker.stopTracker()
+	}
+}
+
+//sayMiddleware tracks the state of the middleware on a channel.
+//when a say is sent to a channel, it is intercepted by the first case. if the rate limit is enabled,
+//the message is sent to the queue. if it is not enabled, it is pushed directly to client.send()
+//a new message on pushing to the queue checks if the queue is disabled, and if it is, reinables and restarts it.
+func (c *Client) sayMiddleware(channel string) {
+	r, ok := c.sayLimiters[channel]
+
+	if !ok {
+		// there was an error here and it must have departed before joining.
+		return
+	}
+	messageChan := r.messageChanel
+	for {
+		select {
+		case message := <-messageChan:
+			if r.isMod {
+				if c.sayModRateLimit != IgnoreRatelimit {
+					if !r.tickerRunning {
+						r.ticker.Reset(c.sayModRateLimit)
+						r.tickerRunning = true
+						//TODO add mutex to prevent perpetual lockout if keep resetting the timer?
+						//is this safe because only one middleware is active at once?
+						//may need to add lock to ratetimeLimiter?
+					}
+					r.messages.PushBack(message)
+				} else {
+					c.send(message)
+				}
+			} else {
+				if c.sayRateLimit != IgnoreRatelimit {
+					if !r.tickerRunning {
+						r.ticker.Reset(c.sayRateLimit)
+						r.tickerRunning = true
+					}
+					r.messages.PushBack(message)
+				} else {
+					c.send(message)
+				}
+			}
+		case <-r.messageContext.Done():
+			//empty queue
+			r.messages.Init()
+			//turn off ticker,
+			r.ticker.Stop()
+			r.tickerRunning = false
+			//no longer listening for user.
+			return
+		case <-r.ticker.C:
+
+			potentialMessage := r.messages.Front()
+			if potentialMessage == nil {
+				r.ticker.Stop()
+				r.tickerRunning = false
+				continue
+			}
+			r.messages.Remove(potentialMessage)
+			message, ok := potentialMessage.Value.(string)
+			if !ok {
+				continue
+			}
+			c.send(message)
+
+		}
+	}
+
+}
+
+func (c *Client) whisperMiddleware() {
+	r := c.whisperLimiter
+	for {
+		select {
+		case message := <-r.messageChanel:
+			if c.whisperRatelimit != IgnoreRatelimit {
+				if !r.tickerRunning {
+					r.ticker.Reset(c.whisperRatelimit)
+					r.tickerRunning = true
+				}
+				r.messages.PushBack(message)
+			} else {
+				c.send(message)
+			}
+		case <-r.messageContext.Done():
+			//empty queue
+			r.messages.Init()
+			//turn off ticker,
+			r.ticker.Stop()
+			r.tickerRunning = false
+			//no longer listening for user.
+			return
+		case <-r.ticker.C:
+			potentialMessage := r.messages.Front()
+			if potentialMessage == nil {
+				r.ticker.Stop()
+				r.tickerRunning = false
+				continue
+			}
+			r.messages.Remove(potentialMessage)
+			message, ok := potentialMessage.Value.(string)
+			if !ok {
+				continue
+			}
+			c.send(message)
+		}
+	}
+}
+
+func (c *Client) joinMiddleware() {
+	r := c.joinLimiter
+	for {
+		select {
+		case message := <-r.messageChanel:
+			if c.joinRateLimit != IgnoreRatelimit {
+				if !r.tickerRunning {
+					r.ticker.Reset(c.joinRateLimit)
+					r.tickerRunning = true
+				}
+				r.messages.PushBack(message)
+			} else {
+				c.send(message)
+			}
+		case <-r.messageContext.Done():
+			//empty queue
+			r.messages.Init()
+			//turn off ticker,
+			r.ticker.Stop()
+			r.tickerRunning = false
+			//no longer listening for user.
+			return
+		case <-r.ticker.C:
+			potentialMessage := r.messages.Front()
+			if potentialMessage == nil {
+				r.ticker.Stop()
+				r.tickerRunning = false
+				continue
+			}
+			r.messages.Remove(potentialMessage)
+			message, ok := potentialMessage.Value.(string)
+			if !ok {
+				continue
+			}
+			c.send(message)
+		}
+	}
+}
+
+func (c *Client) authMiddleware() {
+	r := c.authLimiter
+	for {
+		select {
+		case message := <-r.messageChanel:
+			if c.authRateLimit != IgnoreRatelimit {
+				if !r.tickerRunning {
+					r.ticker.Reset(c.authRateLimit)
+					r.tickerRunning = true
+				}
+				r.messages.PushBack(message)
+			} else {
+				c.send(message)
+			}
+		case <-r.messageContext.Done():
+			//empty queue
+			r.messages.Init()
+			//turn off ticker,
+			r.ticker.Stop()
+			r.tickerRunning = false
+			//no longer listening for user.
+			return
+		case <-r.ticker.C:
+			potentialMessage := r.messages.Front()
+			if potentialMessage == nil {
+				r.ticker.Stop()
+				r.tickerRunning = false
+				continue
+			}
+			r.messages.Remove(potentialMessage)
+			message, ok := potentialMessage.Value.(string)
+			if !ok {
+				continue
+			}
+			c.send(message)
+		}
+	}
+}
+
+//RateLimiter acts as a go-between for the messages sent to the channel, and the output.
+//Each message is sent after each tick of a ticker.
+//If no messages are sent after a time, the ticker is stopped.
+type RateLimiter struct {
+	messages             *list.List
+	isMod                bool
+	messageChanel        chan string
+	messageContext       context.Context
+	messageContextCancel context.CancelFunc
+	ticker               *time.Ticker
+	//todo add update time chan
+	tickerRunning bool
+}
+
+func (t *RateLimiter) startTracker(rate time.Duration) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.messageContext = ctx
+	t.messageContextCancel = cancel
+	t.ticker = time.NewTicker(rate)
+}
+
+func (t *RateLimiter) stopTracker() {
+	if t.messageContextCancel != nil {
+		t.messageContextCancel()
+	}
+}


### PR DESCRIPTION
Messages are sent to the newly created rateLimiter instead of to client.send, put into a queue, and then based on the set timer, output to client.send. 

Current default for ratelimits is for unknown bots. (not Verified or Known, and not unlimited.)