### PR TITLE
Added emote position extraction to emote parse.

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -163,6 +163,7 @@ func TestCanParseEmoteMessage(t *testing.T) {
 	assertStringsEqual(t, "120232", privateMessage.Emotes[0].ID)
 	assertStringsEqual(t, "TriHard", privateMessage.Emotes[0].Name)
 	assertIntsEqual(t, 5, privateMessage.Emotes[0].Count)
+	assertIntsEqual(t, 5, len(privateMessage.Emotes[0].Positions))
 }
 
 func TestCanHandleBadEmoteMessage(t *testing.T) {


### PR DESCRIPTION
This CL adds a new field called Positions to the Emote struct. Positions is a list of EmotePosition, which marks the start and end character of an emote, as sent by the Twitch API.

This allows for downstream consumers of this library to quickly replace emotes in text, without the need to parse/regex the message string.