### PR TITLE
fix #164 and respect ratelimit for bulk joins

### DIFF
--- a/client.go
+++ b/client.go
@@ -688,13 +688,16 @@ func (c *Client) Connect() error {
 	}
 
 	var conf *tls.Config
-	// This means we are connecting to "localhost". Disable certificate chain check
 	if strings.HasPrefix(c.IrcAddress, "127.0.0.1:") {
 		conf = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			//nolint:gosec // disable certificate chain check locally
 			InsecureSkipVerify: true,
 		}
 	} else {
-		conf = &tls.Config{}
+		conf = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 
 	for {

--- a/client.go
+++ b/client.go
@@ -734,8 +734,6 @@ func (c *Client) makeConnection(dialer *net.Dialer, conf *tls.Config) (err error
 	wg.Add(1)
 	go c.startReader(conn, &wg)
 
-	go c.rateLimiter.Start()
-
 	if c.SendPings {
 		// If SendPings is true (which it is by default), start the thread
 		// responsible for managing sending pings and reading pongs
@@ -898,7 +896,6 @@ func (c *Client) writeMessage(writer io.WriteCloser, msg string) {
 		splits := strings.Split(msg, ",")
 		c.rateLimiter.Throttle(len(splits))
 	}
-	fmt.Printf("%s sending %d %s\n", time.Now(), len(c.rateLimiter.throttle), msg)
 
 	_, err := writer.Write([]byte(msg + "\r\n"))
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -573,14 +573,12 @@ func (c *Client) Whisper(username, text string) {
 // This is not a blocking operation.
 func (c *Client) Join(channels ...string) {
 	messages, joined := c.createJoinMessages(channels...)
-	fmt.Printf("join messages: %s\n", messages)
 
 	// If we have an active connection, explicitly join
 	// before we add the joined channels to our map
 	c.channelsMtx.Lock()
 	for _, message := range messages {
 		if c.connActive.get() {
-			fmt.Println("c.send: " + message)
 			c.send(message)
 		}
 	}
@@ -894,13 +892,10 @@ func (c *Client) startWriter(writer io.WriteCloser, wg *sync.WaitGroup) {
 }
 
 func (c *Client) writeMessage(writer io.WriteCloser, msg string) {
-	fmt.Println("writeMessage: " + msg)
 	if strings.HasPrefix(msg, "JOIN") {
 		splits := strings.Split(msg, ",")
 		c.rateLimiter.Throttle(len(splits))
 	}
-
-	fmt.Printf("actually send: %s\n", msg)
 
 	_, err := writer.Write([]byte(msg + "\r\n"))
 	if err != nil {
@@ -945,7 +940,6 @@ func (c *Client) send(line string) {
 	select {
 	case c.write <- line:
 	default:
-		fmt.Println("write buffer overshot")
 		// The buffer of c.write is full, queue up the message to be sent later.
 		// We have no guarantee of order anymore if the buffer is full
 		go func() {

--- a/client.go
+++ b/client.go
@@ -447,7 +447,7 @@ func NewClient(username, oauth string) *Client {
 		// NOTE: IdlePingInterval must be higher than PongTimeout
 		SendPings:        true,
 		IdlePingInterval: time.Second * 15,
-		PongTimeout:      time.Second * 15,
+		PongTimeout:      time.Second * 5,
 
 		channelUserlistMutex: &sync.RWMutex{},
 

--- a/client.go
+++ b/client.go
@@ -630,7 +630,7 @@ func (c *Client) createJoinMessages(channels ...string) ([]string, []string) {
 			continue
 		}
 		c.channelsMtx.Unlock()
-		if sb.Len()+len(channel)+2 > maxMessageLength || channelsWritten >= c.rateLimiter.joinLimit {
+		if sb.Len()+len(channel)+2 > maxMessageLength || (!c.rateLimiter.isUnlimited() && channelsWritten >= c.rateLimiter.joinLimit) {
 			joinMessages = append(joinMessages, sb.String())
 			sb.Reset()
 			sb.WriteString(baseMessage)
@@ -898,6 +898,7 @@ func (c *Client) writeMessage(writer io.WriteCloser, msg string) {
 		splits := strings.Split(msg, ",")
 		c.rateLimiter.Throttle(len(splits))
 	}
+	fmt.Printf("%s sending %d %s\n", time.Now(), len(c.rateLimiter.throttle), msg)
 
 	_, err := writer.Write([]byte(msg + "\r\n"))
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -636,7 +636,7 @@ func (c *Client) createJoinMessages(channels ...string) ([]string, []string) {
 			sb.WriteString(baseMessage)
 			channelsWritten = 0
 		}
-		if sb.Len() == len(baseMessage) {
+		if channelsWritten == 0 {
 			sb.WriteString(" #" + channel)
 			channelsWritten++
 		} else {

--- a/client.go
+++ b/client.go
@@ -447,7 +447,7 @@ func NewClient(username, oauth string) *Client {
 		// NOTE: IdlePingInterval must be higher than PongTimeout
 		SendPings:        true,
 		IdlePingInterval: time.Second * 15,
-		PongTimeout:      time.Second * 5,
+		PongTimeout:      time.Second * 15,
 
 		channelUserlistMutex: &sync.RWMutex{},
 
@@ -719,7 +719,6 @@ func (c *Client) makeConnection(dialer *net.Dialer, conf *tls.Config) (err error
 		conn, err = dialer.Dial("tcp", c.IrcAddress)
 	}
 	if err != nil {
-		fmt.Printf("error connecting to %s: %s\n", c.IrcAddress, err)
 		return
 	}
 
@@ -806,7 +805,6 @@ func (c *Client) startReader(reader io.Reader, wg *sync.WaitGroup) {
 	for {
 		line, err := tp.ReadLine()
 		if err != nil {
-			fmt.Printf("Error reading from server: %s\n", err)
 			return
 		}
 		messages := strings.Split(line, "\r\n")
@@ -899,7 +897,6 @@ func (c *Client) writeMessage(writer io.WriteCloser, msg string) {
 
 	_, err := writer.Write([]byte(msg + "\r\n"))
 	if err != nil {
-		fmt.Println("writeMessage error: " + err.Error())
 		// Attempt to re-send failed messages
 		c.write <- msg
 

--- a/client_test.go
+++ b/client_test.go
@@ -1229,7 +1229,7 @@ func TestCanRespectDefaultJoinRateLimits(t *testing.T) {
 	assertJoinRatelimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
 }
 
-func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
+func TestCanRespectBulkDefaultJoinRateLimits(t *testing.T) {
 	t.Parallel()
 	waitEnd := make(chan struct{})
 

--- a/client_test.go
+++ b/client_test.go
@@ -1248,10 +1248,9 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 		if strings.HasPrefix(message, "JOIN ") {
 			splits := strings.Split(message, ",")
 			for _, split := range splits {
-				fmt.Println(split)
 				messages = append(messages, timedMessage{split, time.Now()})
 			}
-			fmt.Println(len(messages))
+			fmt.Printf("received joins: %d\n", len(messages))
 
 			if len(messages) == targetJoinCount {
 				close(waitEnd)
@@ -1276,7 +1275,7 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 			channels = append(channels, fmt.Sprintf("gempir%d", j))
 		}
 
-		fmt.Println(channels)
+		fmt.Printf("joins: %v\n", channels)
 		client.Join(channels...)
 		i += perBulk
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1249,7 +1249,7 @@ func TestCanRespectBulkDefaultJoinRateLimits(t *testing.T) {
 	})
 
 	client := newTestClient(host)
-	client.PongTimeout = time.Second * 30
+	client.PongTimeout = time.Second * 60
 	client.SetRateLimiter(CreateDefaultRateLimiter())
 	go client.Connect() //nolint
 

--- a/client_test.go
+++ b/client_test.go
@@ -279,6 +279,7 @@ func TestCanConnectAndAuthenticateWithoutTLS(t *testing.T) {
 	client := NewClient("justinfan123123", oauthCode)
 	client.TLS = false
 	client.IrcAddress = host
+	client.PongTimeout = time.Second * 30
 	go client.Connect()
 
 	select {
@@ -359,7 +360,6 @@ func TestCanCreateClient(t *testing.T) {
 }
 
 func TestCanConnectAndAuthenticate(t *testing.T) {
-	t.Parallel()
 	const oauthCode = "oauth:123123132"
 	wait := make(chan struct{})
 
@@ -373,6 +373,7 @@ func TestCanConnectAndAuthenticate(t *testing.T) {
 	})
 
 	client := newTestClient(host)
+	client.PongTimeout = time.Second * 30
 	connectAndEnsureGoodDisconnect(t, client)
 	defer client.Disconnect()
 
@@ -387,7 +388,6 @@ func TestCanConnectAndAuthenticate(t *testing.T) {
 
 // This test is meant to be a blueprint for a test that needs the flow completely from server start to server stop
 func TestFullConnectAndDisconnect(t *testing.T) {
-	t.Parallel()
 	const oauthCode = "oauth:123123132"
 	waitPass := make(chan struct{})
 	waitServerConnect := make(chan struct{})
@@ -432,7 +432,6 @@ func TestFullConnectAndDisconnect(t *testing.T) {
 }
 
 func TestCanConnectAndAuthenticateAnonymous(t *testing.T) {
-	t.Parallel()
 	const oauthCode = "oauth:59301"
 	waitPass := make(chan struct{})
 	waitServerConnect := make(chan struct{})

--- a/client_test.go
+++ b/client_test.go
@@ -170,6 +170,7 @@ func startServer2(t *testing.T, onConnect func(net.Conn), onMessage func(string)
 		t.Fatal(err)
 	}
 	config := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert},
 	}
 	listener, err := tls.Listen("tcp", s.host, config)
@@ -1249,15 +1250,13 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 
 	host := startServer(t, nothingOnConnect, func(message string) {
 		if strings.HasPrefix(message, "JOIN ") {
-			fmt.Println("RECEIVED: " + message)
 			splits := strings.Split(message, ",")
 			for _, split := range splits {
 				messages = append(messages, timedMessage{split, time.Now()})
 			}
-			fmt.Printf("%s received joins: %d\n", time.Now().Format(time.RFC3339), len(messages))
+			fmt.Printf("received joins [%s]: %d\n", time.Now().Format(time.RFC3339), len(messages))
 
 			if len(messages) == targetJoinCount {
-				fmt.Println("============== CLOSING ===============")
 				close(waitEnd)
 			}
 		}
@@ -1280,7 +1279,6 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 			channels = append(channels, fmt.Sprintf("gempir%d", j))
 		}
 
-		fmt.Printf("joins(%d): %v\n", len(channels), channels)
 		client.Join(channels...)
 		i += perBulk
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -106,7 +106,6 @@ func connectAndEnsureGoodDisconnect(t *testing.T, client *Client) chan struct{} 
 func handleTestConnection(t *testing.T, onConnect func(net.Conn), onMessage func(string), listener net.Listener, wg *sync.WaitGroup) {
 	conn, err := listener.Accept()
 	if err != nil {
-		fmt.Printf("error accepting connection: %s\n", err)
 		t.Error(err)
 	}
 	defer func() {
@@ -121,7 +120,6 @@ func handleTestConnection(t *testing.T, onConnect func(net.Conn), onMessage func
 	for {
 		message, err := tp.ReadLine()
 		if err != nil {
-			fmt.Printf("error readLine: %s\n", err)
 			return
 		}
 		message = strings.Replace(message, "\r\n", "", 1)
@@ -184,7 +182,6 @@ func startServer2(t *testing.T, onConnect func(net.Conn), onMessage func(string)
 
 	go func() {
 		wg.Wait()
-		fmt.Println("server stopped")
 		listener.Close()
 
 		close(s.stopped)
@@ -1254,7 +1251,6 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 			for _, split := range splits {
 				messages = append(messages, timedMessage{split, time.Now()})
 			}
-			fmt.Printf("received joins [%s]: %d\n", time.Now().Format(time.RFC3339), len(messages))
 
 			if len(messages) == targetJoinCount {
 				close(waitEnd)
@@ -1263,6 +1259,7 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 	})
 
 	client := newTestClient(host)
+	client.PongTimeout = time.Second * 30
 	client.SetRateLimiter(CreateDefaultRateLimiter())
 	go client.Connect() //nolint
 
@@ -1286,7 +1283,7 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 	// wait for server to receive message
 	select {
 	case <-waitEnd:
-	case <-time.After(time.Second * 5000):
+	case <-time.After(time.Second * 30):
 		t.Fatal("didn't receive all messages in time")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1225,7 +1225,7 @@ func TestCanRespectDefaultJoinRateLimits(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertJoinRatelimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
+	assertJoinRateLimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
 }
 
 func TestCanRespectBulkDefaultJoinRateLimits(t *testing.T) {
@@ -1277,7 +1277,7 @@ func TestCanRespectBulkDefaultJoinRateLimits(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertJoinRatelimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
+	assertJoinRateLimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
 }
 
 func TestCanRespectVerifiedJoinRateLimits(t *testing.T) {
@@ -1319,7 +1319,7 @@ func TestCanRespectVerifiedJoinRateLimits(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertJoinRatelimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
+	assertJoinRateLimitRespected(t, client.rateLimiter.joinLimit, joinMessages)
 }
 
 func TestCanIgnoreJoinRateLimits(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -1273,7 +1273,7 @@ func TestCanRespectBulkDefaultJoinRateLimits(t *testing.T) {
 	// wait for server to receive message
 	select {
 	case <-waitEnd:
-	case <-time.After(time.Second * 30):
+	case <-time.After(time.Second * 60):
 		t.Fatal("didn't receive all messages in time")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1210,6 +1210,7 @@ func TestCanRespectDefaultJoinRateLimits(t *testing.T) {
 	})
 
 	client := newTestClient(host)
+	client.PongTimeout = time.Second * 30
 	client.SetRateLimiter(CreateDefaultRateLimiter())
 	go client.Connect() //nolint
 
@@ -1313,6 +1314,7 @@ func TestCanRespectVerifiedJoinRateLimits(t *testing.T) {
 	})
 
 	client := newTestClient(host)
+	client.PongTimeout = time.Second * 30
 	client.SetRateLimiter(CreateVerifiedRateLimiter())
 	go client.Connect() //nolint
 
@@ -1359,6 +1361,7 @@ func TestCanIgnoreJoinRateLimits(t *testing.T) {
 	})
 
 	client := newTestClient(host)
+	client.PongTimeout = time.Second * 30
 	client.SetRateLimiter(CreateUnlimitedRateLimiter())
 	go client.Connect() //nolint
 

--- a/client_test.go
+++ b/client_test.go
@@ -1231,7 +1231,10 @@ func TestCanRespectDefaultJoinRateLimits(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertTrue(t, messages[len(messages)-1].time.Sub(messages[0].time).Seconds() >= 10, "join rate limit not respected")
+	lastMessageTime := messages[len(messages)-1].time
+	firstMessageTime := messages[0].time
+
+	assertTrue(t, lastMessageTime.Sub(firstMessageTime).Seconds() >= 10, fmt.Sprintf("join ratelimit not resepected last message time: %s, first message time: %s", lastMessageTime, firstMessageTime))
 }
 
 func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
@@ -1288,7 +1291,10 @@ func TestCanRespectDefaultJoinRateLimitsWithBulkJoins(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertTrue(t, messages[len(messages)-1].time.Sub(messages[0].time).Seconds() >= 10, "join rate limit not respected")
+	lastMessageTime := messages[len(messages)-1].time
+	firstMessageTime := messages[0].time
+
+	assertTrue(t, lastMessageTime.Sub(firstMessageTime).Seconds() >= 10, fmt.Sprintf("join ratelimit not resepected last message time: %s, first message time: %s", lastMessageTime, firstMessageTime))
 }
 
 func TestCanRespectVerifiedJoinRateLimits(t *testing.T) {
@@ -1335,7 +1341,10 @@ func TestCanRespectVerifiedJoinRateLimits(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertTrue(t, messages[len(messages)-1].time.Sub(messages[0].time).Seconds() >= 10, "join rate limit not respected")
+	lastMessageTime := messages[len(messages)-1].time
+	firstMessageTime := messages[0].time
+
+	assertTrue(t, lastMessageTime.Sub(firstMessageTime).Seconds() >= 10, fmt.Sprintf("join ratelimit not resepected last message time: %s, first message time: %s", lastMessageTime, firstMessageTime))
 }
 
 func TestCanIgnoreJoinRateLimits(t *testing.T) {
@@ -1382,7 +1391,10 @@ func TestCanIgnoreJoinRateLimits(t *testing.T) {
 		t.Fatal("didn't receive all messages in time")
 	}
 
-	assertTrue(t, messages[len(messages)-1].time.Sub(messages[0].time).Seconds() <= 10, "join rate limit respected")
+	lastMessageTime := messages[len(messages)-1].time
+	firstMessageTime := messages[0].time
+
+	assertTrue(t, lastMessageTime.Sub(firstMessageTime).Seconds() <= 10, fmt.Sprintf("join ratelimit not skipped last message time: %s, first message time: %s", lastMessageTime, firstMessageTime))
 }
 
 func TestCanDepartChannel(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -127,7 +127,7 @@ type timedTestMessage struct {
 	time    time.Time
 }
 
-func assertJoinRatelimitRespected(t *testing.T, joinLimit int, joinMessages []timedTestMessage) {
+func assertJoinRateLimitRespected(t *testing.T, joinLimit int, joinMessages []timedTestMessage) {
 	messageBuckets := make(map[string][]timedTestMessage)
 	startBucketTime := joinMessages[0].time
 	endBucketTime := startBucketTime.Add(TwitchRateLimitWindow)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -130,14 +130,14 @@ type timedTestMessage struct {
 func assertJoinRatelimitRespected(t *testing.T, joinLimit int, joinMessages []timedTestMessage) {
 	messageBuckets := make(map[string][]timedTestMessage)
 	currentMessage := joinMessages[0]
-	currentBucket := currentMessage.time.Add(time.Second * 10)
+	currentBucket := currentMessage.time.Add(TwitchRatelimitWindow)
 
 	for _, msg := range joinMessages {
 		if msg.time.Before(currentBucket) {
 			key := currentMessage.time.Format("15:04:05") + " -> " + currentBucket.Format("15:04:05")
 			messageBuckets[key] = append(messageBuckets[key], msg)
 		} else {
-			currentBucket = msg.time.Add(time.Second * 10)
+			currentBucket = msg.time.Add(TwitchRatelimitWindow)
 			currentMessage = msg
 		}
 	}

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -10,7 +10,7 @@ type RateLimiter struct {
 }
 
 const Unlimited = -1
-const TwitchRatelimitWindow = 10 * time.Second
+const TwitchRateLimitWindow = 10 * time.Second
 
 func CreateDefaultRateLimiter() *RateLimiter {
 	return createRateLimiter(20)
@@ -57,8 +57,8 @@ func (r *RateLimiter) Start() {
 		r.throttle <- time.Now()
 	}
 
-	tickerTime := TwitchRatelimitWindow / time.Duration(r.joinLimit)
-	time.Sleep(TwitchRatelimitWindow)
+	tickerTime := TwitchRateLimitWindow / time.Duration(r.joinLimit)
+	time.Sleep(TwitchRateLimitWindow)
 
 	ticker := time.NewTicker(tickerTime)
 	for range ticker.C {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -53,12 +53,7 @@ func (r *RateLimiter) Start() {
 		return
 	}
 
-	for i := 0; i < r.joinLimit; i++ {
-		r.throttle <- time.Now()
-	}
-
 	tickerTime := TwitchRateLimitWindow / time.Duration(r.joinLimit)
-	time.Sleep(TwitchRateLimitWindow)
 
 	ticker := time.NewTicker(tickerTime)
 	for range ticker.C {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,7 +1,6 @@
 package twitch
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -42,7 +41,6 @@ func (r *RateLimiter) Throttle(count int) {
 	if r.joinLimit == Unlimited {
 		return
 	}
-	fmt.Println(count, len(r.throttle))
 
 	for i := 0; i < count; i++ {
 		<-r.throttle
@@ -67,7 +65,7 @@ func (r *RateLimiter) fillThrottle() {
 		select {
 		case r.throttle <- time.Now():
 		default:
-			fmt.Printf("discarding rest of throttle %d\n", len(r.throttle))
+			// discarding rest, throttle already filled
 		}
 	}
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,6 +1,7 @@
 package twitch
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -36,8 +37,11 @@ func (r *RateLimiter) Throttle(count int) {
 	}
 
 	for i := 0; i < count; i++ {
+		fmt.Printf("%d\n", i)
 		<-r.throttle
+		fmt.Println("more")
 	}
+	fmt.Println("throttle done")
 }
 
 func (r *RateLimiter) Start() {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,13 +1,13 @@
 package twitch
 
 import (
-	"fmt"
+	"sort"
 	"time"
 )
 
 type RateLimiter struct {
 	joinLimit int
-	throttle  chan time.Time
+	window    []time.Time
 }
 
 const Unlimited = -1
@@ -26,16 +26,11 @@ func CreateUnlimitedRateLimiter() *RateLimiter {
 }
 
 func createRateLimiter(limit int) *RateLimiter {
-	var throttle chan time.Time
-	if limit == Unlimited {
-		throttle = make(chan time.Time)
-	} else {
-		throttle = make(chan time.Time, limit)
-	}
+	var window []time.Time
 
 	return &RateLimiter{
 		joinLimit: limit,
-		throttle:  throttle,
+		window:    window,
 	}
 }
 
@@ -44,38 +39,27 @@ func (r *RateLimiter) Throttle(count int) {
 		return
 	}
 
-	for i := 0; i < count; i++ {
-		<-r.throttle
+	newWindow := []time.Time{}
+
+	for i := 0; i < len(r.window); i++ {
+		if r.window[i].Add(TwitchRateLimitWindow).After(time.Now()) {
+			newWindow = append(newWindow, r.window[i])
+		}
 	}
+
+	sort.Slice(newWindow, func(i, j int) bool { return newWindow[i].Before(newWindow[j]) })
+	if r.joinLimit-len(newWindow) > count || len(newWindow) == 0 {
+		for i := 0; i < count; i++ {
+			newWindow = append(newWindow, time.Now())
+		}
+		r.window = newWindow
+		return
+	}
+
+	time.Sleep(time.Until(r.window[0].Add(TwitchRateLimitWindow)))
+	r.Throttle(count)
 }
 
 func (r *RateLimiter) isUnlimited() bool {
 	return r.joinLimit == Unlimited
-}
-
-func (r *RateLimiter) Start() {
-	if r.joinLimit == Unlimited {
-		return
-	}
-
-	r.fillBucket()
-
-	ticker := time.NewTicker(TwitchRateLimitWindow)
-	for range ticker.C {
-		r.fillBucket()
-	}
-}
-
-func (r *RateLimiter) fillBucket() {
-	fmt.Printf("%s Filling bucket %d\n", time.Now(), len(r.throttle))
-
-	fillSize := r.joinLimit - len(r.throttle)
-	for i := 0; i < fillSize; i++ {
-		select {
-		case r.throttle <- time.Now():
-		default:
-			fmt.Printf("%s Bucket is full\n", time.Now())
-			// discard
-		}
-	}
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -30,12 +30,14 @@ func createRateLimiter(limit int) *RateLimiter {
 	}
 }
 
-func (r *RateLimiter) Throttle() {
+func (r *RateLimiter) Throttle(count int) {
 	if r.joinLimit == Unlimited {
 		return
 	}
 
-	<-r.throttle
+	for i := 0; i < count; i++ {
+		<-r.throttle
+	}
 }
 
 func (r *RateLimiter) Start() {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -54,8 +54,7 @@ func (r *RateLimiter) Throttle(count int) {
 		return
 	}
 
-	time.Sleep(time.Until(r.window[0].Add(TwitchRateLimitWindow)))
-	time.Sleep(time.Second)
+	time.Sleep(time.Until(r.window[0].Add(TwitchRateLimitWindow).Add(time.Millisecond * 100)))
 	r.Throttle(count)
 }
 

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,7 +1,6 @@
 package twitch
 
 import (
-	"sort"
 	"time"
 )
 
@@ -47,7 +46,6 @@ func (r *RateLimiter) Throttle(count int) {
 		}
 	}
 
-	sort.Slice(newWindow, func(i, j int) bool { return newWindow[i].Before(newWindow[j]) })
 	if r.joinLimit-len(newWindow) > count || len(newWindow) == 0 {
 		for i := 0; i < count; i++ {
 			newWindow = append(newWindow, time.Now())

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -55,6 +55,7 @@ func (r *RateLimiter) Throttle(count int) {
 	}
 
 	time.Sleep(time.Until(r.window[0].Add(TwitchRateLimitWindow)))
+	time.Sleep(time.Second)
 	r.Throttle(count)
 }
 


### PR DESCRIPTION
Ratelimiting implemented based on a slice with times in it. All the other examples of sliding window implementations looked super complicated to me and not so straight forward.

I'm not sure if this is the correct way to solve this problem, but at least my tests run now. Which they haven't done for any implementation before as you can see by the build history.

One slight weird thing still is I added a 100ms extra sleep, because on CI it kept failing, locally I could run it fine. This is slightly alarming because I'm wondering if on different systems it could behave even differently.

But running `go test -race` brings up no issues.