### PR TITLE
Added First Message support to Twitch user messages.

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,18 +111,19 @@ func (msg *WhisperMessage) GetType() MessageType {
 type PrivateMessage struct {
 	User User
 
-	Raw     string
-	Type    MessageType
-	RawType string
-	Tags    map[string]string
-	Message string
-	Channel string
-	RoomID  string
-	ID      string
-	Time    time.Time
-	Emotes  []*Emote
-	Bits    int
-	Action  bool
+	Raw          string
+	Type         MessageType
+	RawType      string
+	Tags         map[string]string
+	Message      string
+	Channel      string
+	RoomID       string
+	ID           string
+	Time         time.Time
+	Emotes       []*Emote
+	Bits         int
+	Action       bool
+	FirstMessage bool
 }
 
 // GetType implements the Message interface, and returns this message's type

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -22,6 +22,12 @@ func assertInt32sEqual(t *testing.T, expected, actual int32) {
 	}
 }
 
+func assertBoolEqual(t *testing.T, expected, actual bool) {
+	if expected != actual {
+		t.Errorf("failed asserting that \"%t\" is expected \"%t\"", actual, expected)
+	}
+}
+
 func assertTrue(t *testing.T, actual bool, errorMessage string) {
 	if !actual {
 		t.Error(errorMessage)

--- a/message.go
+++ b/message.go
@@ -239,13 +239,11 @@ func parsePrivateMessage(message *ircMessage) Message {
 	privateMessage.Emotes = parseEmotes(message.Tags["emotes"], privateMessage.Message)
 
 	firstMessage, ok := message.Tags["first-msg"]
+
 	if ok {
-		if firstMessage == "0" {
-			privateMessage.FirstMessage = false
-		} else {
-			privateMessage.FirstMessage = true
-		}
+		privateMessage.FirstMessage = firstMessage == "1"
 	}
+
 	return &privateMessage
 }
 

--- a/message.go
+++ b/message.go
@@ -238,6 +238,14 @@ func parsePrivateMessage(message *ircMessage) Message {
 
 	privateMessage.Emotes = parseEmotes(message.Tags["emotes"], privateMessage.Message)
 
+	firstMessage, ok := message.Tags["first-msg"]
+	if ok {
+		if firstMessage == "0" {
+			privateMessage.FirstMessage = false
+		} else {
+			privateMessage.FirstMessage = true
+		}
+	}
 	return &privateMessage
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -188,6 +188,7 @@ func TestCanParsePRIVMSGMessage(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			message := ParseMessage(tt.message)
@@ -216,7 +217,6 @@ func TestCanParsePRIVMSGMessage(t *testing.T) {
 			assertBoolEqual(t, tt.expectedMessage.FirstMessage, privateMessage.FirstMessage)
 		})
 	}
-
 }
 
 func TestCanParsePRIVMSGActionMessage(t *testing.T) {

--- a/message_test.go
+++ b/message_test.go
@@ -190,32 +190,34 @@ func TestCanParsePRIVMSGMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			message := ParseMessage(tt.message)
-			privateMessage := message.(*PrivateMessage)
-			user := privateMessage.User
+		func(tt test) {
+			t.Run(tt.name, func(t *testing.T) {
+				message := ParseMessage(tt.message)
+				privateMessage := message.(*PrivateMessage)
+				user := privateMessage.User
 
-			assertStringsEqual(t, tt.expectedMessage.User.ID, user.ID)
-			assertStringsEqual(t, tt.expectedMessage.User.Name, user.Name)
-			assertStringsEqual(t, tt.expectedMessage.User.DisplayName, user.DisplayName)
-			assertStringsEqual(t, tt.expectedMessage.User.Color, user.Color)
-			assertStringIntMapsEqual(t, tt.expectedMessage.User.Badges, user.Badges)
+				assertStringsEqual(t, tt.expectedMessage.User.ID, user.ID)
+				assertStringsEqual(t, tt.expectedMessage.User.Name, user.Name)
+				assertStringsEqual(t, tt.expectedMessage.User.DisplayName, user.DisplayName)
+				assertStringsEqual(t, tt.expectedMessage.User.Color, user.Color)
+				assertStringIntMapsEqual(t, tt.expectedMessage.User.Badges, user.Badges)
 
-			if privateMessage.Type != tt.expectedMessage.Type {
-				t.Error("parsing MessageType failed")
-			}
+				if privateMessage.Type != tt.expectedMessage.Type {
+					t.Error("parsing MessageType failed")
+				}
 
-			assertStringsEqual(t, tt.expectedMessage.RawType, privateMessage.RawType)
-			assertStringsEqual(t, tt.expectedMessage.Message, privateMessage.Message)
-			assertStringsEqual(t, tt.expectedMessage.Channel, privateMessage.Channel)
-			assertStringsEqual(t, tt.expectedMessage.RoomID, privateMessage.RoomID)
-			assertStringsEqual(t, tt.expectedMessage.ID, privateMessage.ID)
-			assertBoolEqual(t, tt.expectedMessage.Action, privateMessage.Action)
+				assertStringsEqual(t, tt.expectedMessage.RawType, privateMessage.RawType)
+				assertStringsEqual(t, tt.expectedMessage.Message, privateMessage.Message)
+				assertStringsEqual(t, tt.expectedMessage.Channel, privateMessage.Channel)
+				assertStringsEqual(t, tt.expectedMessage.RoomID, privateMessage.RoomID)
+				assertStringsEqual(t, tt.expectedMessage.ID, privateMessage.ID)
+				assertBoolEqual(t, tt.expectedMessage.Action, privateMessage.Action)
 
-			assertIntsEqual(t, len(tt.expectedMessage.Emotes), len(privateMessage.Emotes))
-			assertIntsEqual(t, tt.expectedMessage.Bits, privateMessage.Bits)
-			assertBoolEqual(t, tt.expectedMessage.FirstMessage, privateMessage.FirstMessage)
-		})
+				assertIntsEqual(t, len(tt.expectedMessage.Emotes), len(privateMessage.Emotes))
+				assertIntsEqual(t, tt.expectedMessage.Bits, privateMessage.Bits)
+				assertBoolEqual(t, tt.expectedMessage.FirstMessage, privateMessage.FirstMessage)
+			})
+		}(tt)
 	}
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -115,7 +115,7 @@ func TestCanParseWHISPERActionMessage(t *testing.T) {
 }
 
 func TestCanParsePRIVMSGMessage(t *testing.T) {
-	testMessage := "@badges=premium/1;color=#DAA520;display-name=FletcherCodes;emotes=;flags=;id=6efffc70-27a1-4637-9111-44e5104bb7da;mod=0;room-id=408892348;subscriber=0;tmi-sent-ts=1551473087761;turbo=0;user-id=269899575;user-type= :fletchercodes!fletchercodes@fletchercodes.tmi.twitch.tv PRIVMSG #clippyassistant :Chew your food slower... it's healthier"
+	testMessage := "@badges=premium/1;color=#DAA520;display-name=FletcherCodes;emotes=;first-msg=1;flags=;id=6efffc70-27a1-4637-9111-44e5104bb7da;mod=0;room-id=408892348;subscriber=0;tmi-sent-ts=1551473087761;turbo=0;user-id=269899575;user-type= :fletchercodes!fletchercodes@fletchercodes.tmi.twitch.tv PRIVMSG #clippyassistant :Chew your food slower... it's healthier"
 
 	message := ParseMessage(testMessage)
 	privateMessage := message.(*PrivateMessage)
@@ -142,6 +142,7 @@ func TestCanParsePRIVMSGMessage(t *testing.T) {
 	assertFalse(t, privateMessage.Action, "parsing Action failed")
 	assertIntsEqual(t, 0, len(privateMessage.Emotes))
 	assertIntsEqual(t, 0, privateMessage.Bits)
+	assertTrue(t, privateMessage.FirstMessage, "first message not correctly read")
 }
 
 func TestCanParsePRIVMSGActionMessage(t *testing.T) {


### PR DESCRIPTION
Twitch now sends to moderators and stream owners a new tag with all chat messages, "first-msg=N" where N is 0 or 1. If it's 1, this is the first time this user chatted on the target user's stream. This CL adds support for parsing that tag, and adds a new boolean to the private message struct called FirstMessage to reflect this status.