### PR TITLE
Suggestions for the outofbounds PR

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestCanPraseBadActionMessageWithoutPanic(t *testing.T) {
-	testMessage := "@badges=;color=;display-name=pajlada;emotes=;mod=0;room-id=11148817;subscriber=0;tmi-sent-ts=1522855191000;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :ACTION"
+	testMessage := "@badges=;color=;display-name=pajlada;emotes=;mod=0;room-id=11148817;subscriber=0;tmi-sent-ts=1522855191000;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :\u0001ACTION\u0001"
 	message := ParseMessage(testMessage)
 	msg := message.(*PrivateMessage)
 

--- a/message_test.go
+++ b/message_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestCanPraseBadActionMessageWithoutPanic(t *testing.T) {
-	//nolint
-	message := ParseMessage("@badges=;color=;display-name=pajlada;emotes=;mod=0;room-id=11148817;subscriber=0;tmi-sent-ts=1522855191000;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :ACTION")
+	testMessage := "@badges=;color=;display-name=pajlada;emotes=;mod=0;room-id=11148817;subscriber=0;tmi-sent-ts=1522855191000;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :ACTION"
+	message := ParseMessage(testMessage)
 	msg := message.(*PrivateMessage)
 
 	assertStringsEqual(t, "11148817", msg.User.ID)

--- a/message_test.go
+++ b/message_test.go
@@ -6,6 +6,7 @@ import (
 
 func TestCanPraseBadActionMessageWithoutPanic(t *testing.T) {
 	testMessage := "@badges=;color=;display-name=pajlada;emotes=;mod=0;room-id=11148817;subscriber=0;tmi-sent-ts=1522855191000;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :\u0001ACTION\u0001"
+
 	message := ParseMessage(testMessage)
 	msg := message.(*PrivateMessage)
 


### PR DESCRIPTION
- Move the test message to its own variable
- Use escape sequences instead of literal unicode control character
- consistent spacing with other tests
