### PR TITLE
Add callbacks for self JOIN/PART messages

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -244,6 +244,8 @@ client.OnGlobalUserStateMessage(func(message GlobalUserStateMessage) {})
 client.OnNoticeMessage(func(message NoticeMessage) {})
 client.OnUserJoinMessage(func(message UserJoinMessage) {})
 client.OnUserPartMessage(func(message UserPartMessage) {})
+client.OnSelfJoinMessage(func(message UserJoinMessage) {})
+client.OnSelfPartMessage(func(message UserPartMessage) {})
 ```
 
 ### Message Types

--- a/client.go
+++ b/client.go
@@ -1053,7 +1053,7 @@ func (c *Client) handleLine(line string) error {
 	case *UserJoinMessage:
 		c.handleUserJoinMessage(*msg)
 		if msg.User == c.ircUser {
-			if c.onUserJoinMessage != nil {
+			if c.onSelfJoinMessage != nil {
 				c.onSelfJoinMessage(*msg)
 			}
 		}
@@ -1062,7 +1062,7 @@ func (c *Client) handleLine(line string) error {
 	case *UserPartMessage:
 		c.handleUserPartMessage(*msg)
 		if msg.User == c.ircUser {
-			if c.onUserPartMessage != nil {
+			if c.onSelfPartMessage != nil {
 				c.onSelfPartMessage(*msg)
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -1116,7 +1116,7 @@ func (c *Client) handleNoticeMessage(msg NoticeMessage) error {
 }
 
 func (c *Client) handleUserJoinMessage(msg UserJoinMessage) {
-	// Handle self JOINs on a separate callback
+	// Self JOINs are handled on a separate callback
 	if msg.User == c.ircUser {
 		return
 	}
@@ -1134,7 +1134,7 @@ func (c *Client) handleUserJoinMessage(msg UserJoinMessage) {
 }
 
 func (c *Client) handleUserPartMessage(msg UserPartMessage) {
-	// Handle self PARTs on a separate callback
+	// Self PARTs are handled on a separate callback
 	if msg.User == c.ircUser {
 		return
 	}

--- a/client.go
+++ b/client.go
@@ -1056,6 +1056,10 @@ func (c *Client) handleLine(line string) error {
 			if c.onSelfJoinMessage != nil {
 				c.onSelfJoinMessage(*msg)
 			}
+		} else {
+			if c.onUserJoinMessage != nil {
+				c.onUserJoinMessage(*msg)
+			}
 		}
 		return nil
 
@@ -1064,6 +1068,10 @@ func (c *Client) handleLine(line string) error {
 		if msg.User == c.ircUser {
 			if c.onSelfPartMessage != nil {
 				c.onSelfPartMessage(*msg)
+			}
+		} else {
+			if c.onUserPartMessage != nil {
+				c.onUserPartMessage(*msg)
 			}
 		}
 		return nil


### PR DESCRIPTION
Not sure if it's good to invoke the client callbacks within handle functions for JOIN/PART but it just seemed the simplest.
~~I'm not familiar with library's code much, thus I don't have a good idea about what potentially relevant tests I could add, but I'm open to experimenting and writing something.~~ thanks pajlada for help figuring that out

One small side-note I have: name of the callback `OnUserJoinMessage` might be confusing, indicating it's carrying JOIN message for our user because of the `User` part in its name (ideally `OnJoinMessage` and `OnSelfJoinMessage` would make most sense to me). I know that's the name that was there from the beginning but I think it's only confusing if anything.
That's nothing that I can change though, just pointing that out...

Closes #178
