### PR TITLE
Add client function to return ping latency

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -208,6 +208,7 @@ func (c *Client) Depart(channel string)
 func (c *Client) Userlist(channel string) ([]string, error)
 func (c *Client) Connect() error
 func (c *Client) Disconnect() error
+func (c *Client) Latency() (latency time.Duration, err error)
 ```
 
 ### Options

--- a/client_test.go
+++ b/client_test.go
@@ -1878,6 +1878,7 @@ func TestLatency(t *testing.T) {
 	t.Parallel()
 	const idlePingInterval = 10 * time.Millisecond
 	const expectedLatency = 50 * time.Millisecond
+	const toleranceLatency = 5 * time.Millisecond
 
 	wait := make(chan bool)
 
@@ -1926,7 +1927,7 @@ func TestLatency(t *testing.T) {
 			return diff
 		}()
 
-		if latencyDiff > time.Millisecond*3 {
+		if latencyDiff > toleranceLatency {
 			t.Fatalf("Latency %s should be within 3ms of %s", returnedLatency, expectedLatency)
 		}
 

--- a/client_test.go
+++ b/client_test.go
@@ -17,8 +17,10 @@ import (
 	"time"
 )
 
-var startPortMutex sync.Mutex
-var startPort = 10000
+var (
+	startPortMutex sync.Mutex
+	startPort      = 10000
+)
 
 func newPort() (r int) {
 	startPortMutex.Lock()
@@ -1916,7 +1918,15 @@ func TestLatency(t *testing.T) {
 
 		returnedLatency = returnedLatency.Round(time.Millisecond)
 
-		if returnedLatency != expectedLatency {
+		latencyDiff := func() time.Duration {
+			diff := returnedLatency - expectedLatency
+			if diff < 0 {
+				return -diff
+			}
+			return diff
+		}()
+
+		if latencyDiff > time.Millisecond*3 {
 			t.Fatalf("Latency %s should be equal to %s", returnedLatency, expectedLatency)
 		}
 
@@ -2143,7 +2153,7 @@ func TestCapabilities(t *testing.T) {
 		in       []string
 		expected string
 	}
-	var tests = []testTable{
+	tests := []testTable{
 		{
 			"Default Capabilities (not modifying)",
 			nil,
@@ -2218,7 +2228,7 @@ func TestEmptyCapabilities(t *testing.T) {
 		name string
 		in   []string
 	}
-	var tests = []testTable{
+	tests := []testTable{
 		{"nil", nil},
 		{"Empty list", []string{}},
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1927,7 +1927,7 @@ func TestLatency(t *testing.T) {
 		}()
 
 		if latencyDiff > time.Millisecond*3 {
-			t.Fatalf("Latency %s should be equal to %s", returnedLatency, expectedLatency)
+			t.Fatalf("Latency %s should be within 3ms of %s", returnedLatency, expectedLatency)
 		}
 
 	}


### PR DESCRIPTION
Thought it would be useful to have a client function that returns ping latency like [dank-twitch-irc](https://github.com/kararty/dank-twitch-irc?tab=readme-ov-file#chatclient-api) does.