### PR TITLE
Check for vip & mod status through badges

### DIFF
--- a/message.go
+++ b/message.go
@@ -135,9 +135,24 @@ func parseUser(message *ircMessage) User {
 
 	// https://dev.twitch.tv/docs/chat/irc/#privmsg-tags
 	isBroadcaster = message.Tags["user-id"] == message.Tags["room-id"]
-	_, isVip = message.Tags["vip"]
-	if value, tagFound := message.Tags["mod"]; tagFound {
-		isMod = value == "1"
+
+	userBadges := make(map[string]int)
+	if rawBadges := message.Tags["badges"]; rawBadges != "" {
+		userBadges = parseBadges(rawBadges)
+		// USERSTATE doesn't contain "vip" tag (even if the user is a VIP), we have to check user's badges for that
+		for badge := range userBadges {
+			switch badge {
+			case "vip":
+				isVip = true
+			case "moderator", "lead_moderator":
+				isMod = true
+			}
+		}
+	} else {
+		_, isVip = message.Tags["vip"]
+		if value, tagFound := message.Tags["mod"]; tagFound {
+			isMod = value == "1"
+		}
 	}
 
 	user := User{
@@ -145,14 +160,10 @@ func parseUser(message *ircMessage) User {
 		Name:          message.Source.Username,
 		DisplayName:   message.Tags["display-name"],
 		Color:         message.Tags["color"],
-		Badges:        make(map[string]int),
+		Badges:        userBadges,
 		IsBroadcaster: isBroadcaster,
 		IsMod:         isMod,
 		IsVip:         isVip,
-	}
-
-	if rawBadges := message.Tags["badges"]; rawBadges != "" {
-		user.Badges = parseBadges(rawBadges)
 	}
 
 	// USERSTATE doesn't contain a Username, but it does have a display-name tag

--- a/message.go
+++ b/message.go
@@ -139,14 +139,14 @@ func parseUser(message *ircMessage) User {
 	userBadges := make(map[string]int)
 	if rawBadges := message.Tags["badges"]; rawBadges != "" {
 		userBadges = parseBadges(rawBadges)
-		// USERSTATE doesn't contain "vip" tag (even if the user is a VIP), we have to check user's badges for that
-		for badge := range userBadges {
-			switch badge {
-			case "vip":
-				isVip = true
-			case "moderator", "lead_moderator":
-				isMod = true
-			}
+		// Badges are the primary source for VIP/mod role detection
+		// Some messages (such as USERSTATE) may omit "vip" tag, so we use badges for that when they're present
+		if _, ok := userBadges["vip"]; ok {
+			isVip = true
+		} else if _, ok := userBadges["moderator"]; ok {
+			isMod = true
+		} else if _, ok := userBadges["lead_moderator"]; ok {
+			isMod = true
 		}
 	} else {
 		_, isVip = message.Tags["vip"]

--- a/message_test.go
+++ b/message_test.go
@@ -962,3 +962,42 @@ func TestCanParseSharedChatMessageWithEmptySourceBadges(t *testing.T) {
 		assertStringIntMapsEqual(t, expectedBadges, privateMessage.Source.Badges)
 	}
 }
+
+func TestUserStateMessageFromMod(t *testing.T) {
+	testMessage := "@badge-info=;badges=moderator/1;color=#FF7F50;display-name=TitleChange_Bot;emote-sets=0,300206297,300374282,300548762,472873131,488737509,537206155,564265402,592920959,610186276;id=5f93d69e-13b3-4cd7-a5ee-59c803fa5145;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #zneix"
+
+	message := ParseMessage(testMessage)
+	userStateMessage := message.(*UserStateMessage)
+
+	if userStateMessage.Type != USERSTATE {
+		t.Error("parsing MessageType failed")
+	}
+	assertBoolEqual(t, true, userStateMessage.User.IsMod)
+	assertBoolEqual(t, false, userStateMessage.User.IsVip)
+}
+
+func TestUserStateMessageFromVip(t *testing.T) {
+	testMessage := "@badge-info=;badges=vip/1;color=#FF7F50;display-name=TitleChange_Bot;emote-sets=0,300206297,300374282,300548762,472873131,488737509,537206155,564265402,592920959,610186276;id=2577475f-93e1-4581-9836-70d4087060f9;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #zneix"
+
+	message := ParseMessage(testMessage)
+	userStateMessage := message.(*UserStateMessage)
+
+	if userStateMessage.Type != USERSTATE {
+		t.Error("parsing MessageType failed")
+	}
+	assertBoolEqual(t, false, userStateMessage.User.IsMod)
+	assertBoolEqual(t, true, userStateMessage.User.IsVip)
+}
+
+func TestUserStateMessageFromNonModNonVip(t *testing.T) {
+	testMessage := "@badge-info=;badges=;color=#FF7F50;display-name=TitleChange_Bot;emote-sets=0,300206297,300374282,300548762,472873131,488737509,537206155,564265402,592920959,610186276;id=8f52d7bd-09b2-433e-9cf9-4088e2041aa5;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #zneix"
+
+	message := ParseMessage(testMessage)
+	userStateMessage := message.(*UserStateMessage)
+
+	if userStateMessage.Type != USERSTATE {
+		t.Error("parsing MessageType failed")
+	}
+	assertBoolEqual(t, false, userStateMessage.User.IsMod)
+	assertBoolEqual(t, false, userStateMessage.User.IsVip)
+}


### PR DESCRIPTION
USERSTATE messages have a quirk where they will not include `vip` tag even if the associated user is a VIP.
Example message:
```
@badge-info=;badges=vip/1;color=#FF7F50;display-name=TitleChange_Bot;emote-sets=0,300206297,300374282,300548762,472873131,488737509,537206155,564265402,592920959,610186276;id=2577475f-93e1-4581-9836-70d4087060f9;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #zneix

// formatted

@badge-info=
badges=vip/1
color=#FF7F50
display-name=TitleChange_Bot
emote-sets=0,300206297,300374282,300548762,472873131,488737509,537206155,564265402,592920959,610186276
id=2577475f-93e1-4581-9836-70d4087060f9
mod=0
subscriber=0
user-type=
:tmi.twitch.tv USERSTATE #zneix
```

Checking for `vip` as well as `mod` message tags is said to be deprecated in favour of checking user's badges. (missing actual source but OGProdigy and Leppunen told me so)

I was suggested to keep the tag checks, but I don't think that's how it should be.
Question: is there even a case where badges won't be present but mod/vip tags might hold relevant information?

This is necessary for correctly setting `IsVip` flag for USERSTATE messages.
